### PR TITLE
Adding Request Header which prevented Shopify from exchanging tokens

### DIFF
--- a/lib/resource.js
+++ b/lib/resource.js
@@ -30,6 +30,11 @@
           'X-Shopify-Access-Token': this.oauth_token
         } : {}
       };
+
+      if (method === "POST") {
+        options.headers['Content-Type'] = 'application/x-www-form-urlencoded';
+      }
+
       if (fields != null) {
         params = {};
         if (slug !== 'oauth') {


### PR DESCRIPTION
The Creation of session was failing because Shopify was expecting a `Content-Type` of `application/x-www-form-urlencoded` while exchanging temporary token for a permanent one. 

Added the fix for this issue.
