### PR TITLE
NEEDS FEEDBACK: add metafields for product and variant

### DIFF
--- a/resources/product-variant.js
+++ b/resources/product-variant.js
@@ -49,16 +49,4 @@ ProductVariant.prototype.update = function update(id, params) {
   return this.shopify.request(url, 'PUT', this.key, params);
 };
 
-/**
- * Get all metafields that belong to a product variant
- *
- * @param {Number} variant Variant ID
- * @return {Promise} Promise that resolves with the result
- * @public
- */
-ProductVariant.prototype.metafields = function(id) {
-  const url = this.buildUrl(`${id}/metafields`);
-  return this.shopify.request(url);
-};
-
 module.exports = ProductVariant;

--- a/resources/product-variant.js
+++ b/resources/product-variant.js
@@ -49,4 +49,16 @@ ProductVariant.prototype.update = function update(id, params) {
   return this.shopify.request(url, 'PUT', this.key, params);
 };
 
+/**
+ * Get all metafields that belong to a product variant
+ *
+ * @param {Number} variant Variant ID
+ * @return {Promise} Promise that resolves with the result
+ * @public
+ */
+ProductVariant.prototype.metafields = function(id) {
+  const url = this.buildUrl(`${id}/metafields`);
+  return this.shopify.request(url);
+};
+
 module.exports = ProductVariant;

--- a/resources/product.js
+++ b/resources/product.js
@@ -20,4 +20,16 @@ function Product(shopify) {
 
 assign(Product.prototype, base);
 
+/**
+ * Get all metafields that belong to a product
+ *
+ * @param {Number} product Product ID
+ * @return {Promise} Promise that resolves with the result
+ * @public
+ */
+Product.prototype.metafields = function(id) {
+  const url = this.buildUrl(`${id}/metafields`);
+  return this.shopify.request(url);
+};
+
 module.exports = Product;

--- a/resources/variant.js
+++ b/resources/variant.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const assign = require('lodash/assign');
+const pick = require('lodash/pick');
+
+const base = require('../mixins/base');
+
+/**
+ * Creates a variant instance.
+ *
+ * @param {Shopify} shopify Reference to the Shopify instance
+ * @constructor
+ * @public
+ */
+function Variant(shopify) {
+  this.shopify = shopify;
+
+  this.name = 'variants';
+  this.key = 'variants';
+}
+
+assign(Variant.prototype, pick(base, ['buildUrl']));
+
+/**
+ * Get all metafields that belong to a product
+ *
+ * @param {Number} variant Variant ID
+ * @return {Promise} Promise that resolves with the result
+ * @public
+ */
+Variant.prototype.metafields = function(id) {
+  const url = this.buildUrl(`${id}/metafields`);
+  return this.shopify.request(url);
+};
+
+module.exports = Variant;


### PR DESCRIPTION
I need the metafields from product and variants.  

The /admin/products/#{id}/metafields.json endpoint is documented at  https://help.shopify.com/api/reference/metafield rather than the product reference.  

Since it lives under the product endpoint I added it to the product prototype rather than metafields.  Not sure if this is the way you would want to do it, but it seemed the simplest thing that works for me.