### PR TITLE
Metafieldcreate

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ shopify.order.list({ limit: 5 })
 - product
   - `count([params])`
   - `create(params)`
+  - `createMetafield(id, params)`
   - `delete(id)`
   - `get(id[, params])`
   - `list([params])`
@@ -298,6 +299,7 @@ shopify.order.list({ limit: 5 })
 - productVariant
   - `count(productId)`
   - `create(productId, params)`
+  - `createMetafield(productVariantId, params)`
   - `delete(productId, id)`
   - `get(id[, params])`
   - `list(productId[, params])`

--- a/mixins/base-child.js
+++ b/mixins/base-child.js
@@ -39,6 +39,7 @@ const baseChild = {
 
   /**
    * Creates a new metafield on a record.
+   * This also works to update the existing metafield
    *
    * @param {Number} parentId Parent record ID
    * @param {Object} params Record properties

--- a/mixins/base-child.js
+++ b/mixins/base-child.js
@@ -36,13 +36,22 @@ const baseChild = {
     const url = this.buildUrl(parentId);
     return this.shopify.request(url, 'POST', this.key, params);
   },
+
+  /**
+   * Creates a new metafield on a record.
+   *
+   * @param {Number} parentId Parent record ID
+   * @param {Object} params Record properties
+   * @return {Promise} Promise that resolves with the result
+   * @public
+   */
   createMetafield(parentId, params) {
-    // rearrange arguments
+    // rearrange and override arguments
     this.parentName = this.name;
-    this.name = '';
+    this.name = 'metafield';
     this.key = 'metafield';
 
-    const url = this.buildUrl(parentId, 'metafield');
+    const url = this.buildUrl(parentId);
     return this.shopify.request(url, 'POST', this.key, params);
   },
 

--- a/mixins/base-child.js
+++ b/mixins/base-child.js
@@ -36,6 +36,15 @@ const baseChild = {
     const url = this.buildUrl(parentId);
     return this.shopify.request(url, 'POST', this.key, params);
   },
+  createMetafield(parentId, params) {
+    // rearrange arguments
+    this.parentName = this.name;
+    this.name = '';
+    this.key = 'metafield';
+
+    const url = this.buildUrl(parentId, 'metafield');
+    return this.shopify.request(url, 'POST', this.key, params);
+  },
 
   /**
    * Deletes a record.


### PR DESCRIPTION
Adds a call base-child.js for creating a meta field on a product or product variant. (Updated the readme to match)

The same call to createMetafield will also update the same metafield of the matching namespace/key.

I imagine it would would with anything that can have a metafield.

It uses the (main docs) undocumented API end points discussed [here](https://ecommerce.shopify.com/c/shopify-apis-and-technology/t/updating-product-variant-metafields-166055) by Shopify staff
