### PR TITLE
Apply an EventEmitter to updateLimits

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,13 @@ is an object like this:
 }
 ```
 
-Values start at `undefined` and are updated every time a request is made.
+Values start at `undefined` and are updated every time a request is made. After
+every update the `callLimits` event is emitted with the updated limits as
+argument.
+
+```js
+shopify.on('callLimits', limits => console.log(limits));
+```
 
 ### Resources
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const camelCase = require('lodash/camelCase');
 const defaults = require('lodash/defaults');
 const assign = require('lodash/assign');
+const EventEmitter = require('events');
 const valvelet = require('valvelet');
 const path = require('path');
 const got = require('got');
@@ -34,6 +35,7 @@ function Shopify(options) {
     throw new Error('Missing or invalid options');
   }
 
+  EventEmitter.call(this);
   this.options = defaults(options, { timeout: 60000 });
 
   //
@@ -57,6 +59,8 @@ function Shopify(options) {
   }
 }
 
+Object.setPrototypeOf(Shopify.prototype, EventEmitter.prototype);
+
 /**
  * Updates API call limits.
  *
@@ -72,6 +76,8 @@ Shopify.prototype.updateLimits = function updateLimits(header) {
   callLimits.remaining = limits[1] - limits[0];
   callLimits.current = limits[0];
   callLimits.max = limits[1];
+
+  this.emit('callLimits', callLimits);
 };
 
 /**

--- a/test/shopify.test.js
+++ b/test/shopify.test.js
@@ -262,6 +262,25 @@ describe('Shopify', () => {
       });
     });
 
+    it('emits the `callLimits` event', (done) => {
+      scope
+        .get('/test')
+        .reply(200, {}, {
+          'X-Shopify-Shop-Api-Call-Limit': '6/40'
+        });
+
+      shopify.on('callLimits', limits => {
+        expect(limits).to.deep.equal({
+          remaining: 34,
+          current: 6,
+          max: 40
+        });
+        done();
+      });
+
+      shopify.request(url, 'GET');
+    });
+
     it('does not update callLimits if the relevant header is missing', () => {
       scope
         .get('/test')
@@ -270,8 +289,8 @@ describe('Shopify', () => {
       return shopify.request(url, 'GET')
         .then(() => {
           expect(shopify.callLimits).to.deep.equal({
-            remaining: 35,
-            current: 5,
+            remaining: 34,
+            current: 6,
             max: 40
           });
         });


### PR DESCRIPTION
Adds an EventEmitter to the updateLimits function, so we can obtain limits in real time instead of long polling, for monitoring etc