### PR TITLE
Add TaxService resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,12 @@ shopify.metafield.create({
   - `create(params)`
   - `delete(id)`
   - `list()`
+- taxService
+  - `create(params)`
+  - `delete(id)`
+  - `get(id)`
+  - `list()`
+  - `update(id, params)`
 - theme
   - `create(params)`
   - `delete(id)`

--- a/resources/tax-service.js
+++ b/resources/tax-service.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const assign = require('lodash/assign');
+const omit = require('lodash/omit');
+
+const base = require('../mixins/base');
+
+/**
+ * Creates a TaxService instance.
+ *
+ * @param {Shopify} shopify Reference to the Shopify instance
+ * @constructor
+ * @public
+ */
+function TaxService(shopify) {
+  this.shopify = shopify;
+
+  this.name = 'tax_services';
+  this.key = 'tax_service';
+}
+
+assign(TaxService.prototype, omit(base, ['count', 'delete']));
+
+/**
+ * Destroys a tax service.
+ *
+ * @param {Number} Tax service ID
+ * @return {Promise} Promise that resolves with the result
+ * @public
+ */
+TaxService.prototype.delete = function remove(id) {
+  const url = this.buildUrl(id);
+  return this.shopify.request(url, 'DELETE', this.key);
+};
+
+module.exports = TaxService;

--- a/test/fixtures/tax-service/index.js
+++ b/test/fixtures/tax-service/index.js
@@ -1,0 +1,4 @@
+'use strict';
+
+exports.req = require('./req');
+exports.res = require('./res');

--- a/test/fixtures/tax-service/req/create.json
+++ b/test/fixtures/tax-service/req/create.json
@@ -1,0 +1,6 @@
+{
+  "tax_service": {
+    "name": "My Tax Service",
+    "url": "https://tax.myservice.com"
+  }
+}

--- a/test/fixtures/tax-service/req/index.js
+++ b/test/fixtures/tax-service/req/index.js
@@ -1,0 +1,4 @@
+'use strict';
+
+exports.create = require('./create');
+exports.update = require('./update');

--- a/test/fixtures/tax-service/req/update.json
+++ b/test/fixtures/tax-service/req/update.json
@@ -1,0 +1,8 @@
+{
+  "tax_service": {
+    "id": 760126902,
+    "name": "Some new name",
+    "url": "https://tax-api.avalara.com",
+    "active": true
+  }
+}

--- a/test/fixtures/tax-service/res/create.json
+++ b/test/fixtures/tax-service/res/create.json
@@ -1,0 +1,8 @@
+{
+  "tax_service": {
+    "id": 883755539,
+    "name": "My Tax Service",
+    "url": "https://tax.myservice.com",
+    "active": false
+  }
+}

--- a/test/fixtures/tax-service/res/delete.json
+++ b/test/fixtures/tax-service/res/delete.json
@@ -1,0 +1,8 @@
+{
+  "tax_service": {
+    "id": 760126902,
+    "name": "Avalara",
+    "url": "https://tax-api.avalara.com",
+    "active": false
+  }
+}

--- a/test/fixtures/tax-service/res/get.json
+++ b/test/fixtures/tax-service/res/get.json
@@ -1,0 +1,8 @@
+{
+  "tax_service": {
+    "id": 760126902,
+    "name": "Avalara",
+    "url": "https://tax-api.avalara.com",
+    "active": true
+  }
+}

--- a/test/fixtures/tax-service/res/index.js
+++ b/test/fixtures/tax-service/res/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+exports.create = require('./create');
+exports.delete = require('./delete');
+exports.update = require('./update');
+exports.list = require('./list');
+exports.get = require('./get');

--- a/test/fixtures/tax-service/res/list.json
+++ b/test/fixtures/tax-service/res/list.json
@@ -1,0 +1,10 @@
+{
+  "tax_services": [
+    {
+      "id": 760126902,
+      "name": "Avalara",
+      "url": "https://tax-api.avalara.com",
+      "active": true
+    }
+  ]
+}

--- a/test/fixtures/tax-service/res/update.json
+++ b/test/fixtures/tax-service/res/update.json
@@ -1,0 +1,8 @@
+{
+  "tax_service": {
+    "id": 760126902,
+    "name": "Some new name",
+    "url": "https://tax-api.avalara.com",
+    "active": true
+  }
+}

--- a/test/tax-service.test.js
+++ b/test/tax-service.test.js
@@ -1,0 +1,70 @@
+describe('Shopify#taxService', () => {
+  'use strict';
+
+  const expect = require('chai').expect;
+
+  const fixtures = require('./fixtures/tax-service');
+  const common = require('./common');
+
+  const shopify = common.shopify;
+  const scope = common.scope;
+
+  afterEach(() => expect(scope.isDone()).to.be.true);
+
+  it('creates a tax service', () => {
+    const input = fixtures.req.create;
+    const output = fixtures.res.create;
+
+    scope
+      .post('/admin/tax_services.json', input)
+      .reply(201, output);
+
+    return shopify.taxService.create(input.tax_service)
+      .then(data => expect(data).to.deep.equal(output.tax_service));
+  });
+
+  it('updates a tax service', () => {
+    const input = fixtures.req.update;
+    const output = fixtures.res.update;
+
+    scope
+      .put('/admin/tax_services/760126902.json', input)
+      .reply(200, output);
+
+    return shopify.taxService.update(760126902, input.tax_service)
+      .then(data => expect(data).to.deep.equal(output.tax_service));
+  });
+
+  it('gets a list of all tax services', () => {
+    const output = fixtures.res.list;
+
+    scope
+      .get('/admin/tax_services.json')
+      .reply(200, output);
+
+    return shopify.taxService.list()
+      .then(data => expect(data).to.deep.equal(output.tax_services));
+  });
+
+  it('gets a single tax service by its ID', () => {
+    const output = fixtures.res.get;
+
+    scope
+      .get('/admin/tax_services/760126902.json')
+      .reply(200, output);
+
+    return shopify.taxService.get(760126902)
+      .then(data => expect(data).to.deep.equal(output.tax_service));
+  });
+
+  it('deletes a tax service', () => {
+    const output = fixtures.res.delete;
+
+    scope
+      .delete('/admin/tax_services/760126902.json')
+      .reply(200, output);
+
+    return shopify.taxService.delete(760126902)
+      .then(data => expect(data).to.deep.equal(output.tax_service));
+  });
+});


### PR DESCRIPTION
**Do not merge until we know for sure that https://help.shopify.com/api/reference/taxservice#destroy works as documented.**

This adds the [TaxService](https://help.shopify.com/api/reference/taxservice) resource.
Closes #94.