### PR TITLE
JSDoc improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,15 +13,30 @@ const fs = require('fs');
 const pkg = require('./package');
 
 /**
+ * @typedef {object} ConstructorOptionsAlways
+ * @property {string} shopName
+ * @property {string} [apiKey]
+ * @property {string} [password]
+ * @property {string} [accessToken]
+ * @property {boolean | object} [autoLimit]
+ * @property {number} [timeout]
+ */
+
+/**
+ * @typedef {object} ConstructorOptionsAccessToken
+ * @property {string} accessToken
+ */
+
+/**
+ * @typedef {object} ConstructorOptionsKeyPassword
+ * @property {string} apiKey
+ * @property {string} password
+ */
+
+/**
  * Creates a Shopify instance.
  *
- * @param {Object} options Configuration options
- * @param {String} options.shopName The name of the shop
- * @param {String} options.apiKey The API Key
- * @param {String} options.password The private app password
- * @param {String} options.accessToken The persistent OAuth public app token
- * @param {Boolean|Object} [options.autoLimit] Limits the request rate
- * @param {Number} [options.timeout] The request timeout
+ * @param {ConstructorOptionsAlways & (ConstructorOptionsKeyPassword | ConstructorOptionsAccessToken)} options Configuration options
  * @constructor
  * @public
  */

--- a/index.js
+++ b/index.js
@@ -13,12 +13,19 @@ const fs = require('fs');
 const pkg = require('./package');
 
 /**
+ * @typedef {object} AutoLimitParams
+ * @property {number} [calls]
+ * @property {number} [interval]
+ * @property {number} [bucketSize]
+ */
+
+/**
  * @typedef {object} ConstructorOptionsAlways
  * @property {string} shopName
  * @property {string} [apiKey]
  * @property {string} [password]
  * @property {string} [accessToken]
- * @property {boolean | object} [autoLimit]
+ * @property {boolean | AutoLimitParams} [autoLimit]
  * @property {number} [timeout]
  */
 


### PR DESCRIPTION
Using TypeScript's checkJS functionality in Visual Studio Code, my constructor options were often marked as incorrect.

This will correctly allow IDEs to hint at which properties are allowed.

Unfortunately, I wasn't able to create mutually exclusive definitions of which options are allowed. Which means, at code-time, passing in both `accessToken` and `password` will be marked as correct (at runtime, however, an error will be thrown).

Still, this is an improvement over valid options being marked as invalid.