### PR TITLE
[ts] Improve constructor option definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -408,7 +408,7 @@ declare namespace Shopify {
         accessToken: string;
         autoLimit?: boolean | IAutoLimit;
         shopName: string;
-        timeout: number;
+        timeout?: number;
     }
     
     export interface IPrivateShopifyConfig {
@@ -416,7 +416,7 @@ declare namespace Shopify {
         autoLimit?: boolean | IAutoLimit;
         password: string;
         shopName: string;
-        timeout: number;
+        timeout?: number;
     }
     
     export interface ICallLimits {


### PR DESCRIPTION
- marks timeout as an optional field
- use and extend a common interface for both config interfaces