### PR TITLE
[ts] Fixed Typo - IProudctOptions => IProductOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1442,7 +1442,7 @@ declare namespace Shopify {
         ends_at: string;
     }
 
-    interface IProudctOptions {
+    interface IProductOptions {
         id: number;
         name: string;
         position: number;
@@ -1457,7 +1457,7 @@ declare namespace Shopify {
         id: number;
         image: any | null;
         images: IProductImage[];
-        options: IProudctOptions[];
+        options: IProductOptions[];
         product_type: string;
         published_at: string;
         published_scope: string;


### PR DESCRIPTION
There is a typo in the TS definition, this should be a subtle change. Unsure if you want to introduce some kind of backwards compatibility for `IProudctOptions` (I chose not to clutter things up).