### PR TITLE
Unwrapping the result of /recurring_application_charges//activate API

### DIFF
--- a/resources/recurring-application-charge.js
+++ b/resources/recurring-application-charge.js
@@ -36,7 +36,7 @@ RecurringApplicationCharge.prototype.activate = function activate(id, params) {
   const url = this.buildUrl(`${id}/activate`);
   return this.shopify.request(url, 'POST', undefined, {
     [this.key]: params
-  });
+  }).then(result => result[this.key] || {});
 };
 
 module.exports = RecurringApplicationCharge;

--- a/resources/recurring-application-charge.js
+++ b/resources/recurring-application-charge.js
@@ -34,9 +34,8 @@ assign(RecurringApplicationCharge.prototype, omit(base, [
  */
 RecurringApplicationCharge.prototype.activate = function activate(id, params) {
   const url = this.buildUrl(`${id}/activate`);
-  return this.shopify.request(url, 'POST', undefined, {
-    [this.key]: params
-  }).then(result => result[this.key] || {});
+  return this.shopify.request(url, 'POST', undefined, { [this.key]: params })
+    .then(body => body[this.key]);
 };
 
 module.exports = RecurringApplicationCharge;

--- a/test/fixtures/recurring-application-charge/res/activate.json
+++ b/test/fixtures/recurring-application-charge/res/activate.json
@@ -1,0 +1,19 @@
+{
+  "recurring_application_charge": {
+    "id": 455696195,
+    "name": "Super Mega Plan",
+    "api_client_id": 755357713,
+    "price": "15.00",
+    "status": "active",
+    "return_url": "http://yourapp.com",
+    "billing_on": "2018-08-04",
+    "created_at": "2018-07-05T12:41:00-04:00",
+    "updated_at": "2018-07-05T13:01:15-04:00",
+    "test": null,
+    "activated_on": "2018-07-05",
+    "trial_ends_on": "2018-07-05",
+    "cancelled_on": null,
+    "trial_days": 0,
+    "decorated_return_url": "http://yourapp.com?charge_id=455696195"
+  }
+}

--- a/test/fixtures/recurring-application-charge/res/index.js
+++ b/test/fixtures/recurring-application-charge/res/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+exports.activate = require('./activate');
 exports.create = require('./create');
 exports.list = require('./list');
 exports.get = require('./get');

--- a/test/recurring-application-charge.test.js
+++ b/test/recurring-application-charge.test.js
@@ -78,6 +78,15 @@ describe('Shopify#recurringApplicationCharge', () => {
   });
 
   it('activates a recurring application charge', () => {
+    /**
+     * TODO: According to Shopify API the activation of a charge
+     * should return the updated charge object with the 'status'
+     * value set as 'active'. This test seems to be trying to
+     * activate an invalid charge ID, and might be the reason why
+     * it's returning an empty object. Must be fixed to retrieve
+     * a successful result from the API and create a fixture to
+     * test against.
+     */
     const input = fixtures.req.activate;
     const id = 455696195;
 

--- a/test/recurring-application-charge.test.js
+++ b/test/recurring-application-charge.test.js
@@ -78,24 +78,18 @@ describe('Shopify#recurringApplicationCharge', () => {
   });
 
   it('activates a recurring application charge', () => {
-    /**
-     * TODO: According to Shopify API the activation of a charge
-     * should return the updated charge object with the 'status'
-     * value set as 'active'. This test seems to be trying to
-     * activate an invalid charge ID, and might be the reason why
-     * it's returning an empty object. Must be fixed to retrieve
-     * a successful result from the API and create a fixture to
-     * test against.
-     */
     const input = fixtures.req.activate;
+    const output = fixtures.res.activate;
     const id = 455696195;
 
     scope
       .post(`/admin/recurring_application_charges/${id}/activate.json`, input)
-      .reply(200);
+      .reply(200, output);
 
     return resource.activate(id, input.recurring_application_charge)
-      .then(data => expect(data).to.deep.equal({}));
+      .then(data => {
+        expect(data).to.deep.equal(output.recurring_application_charge);
+      });
   });
 
   it('deletes a recurring application charge', () => {


### PR DESCRIPTION
Now the API wrapper is returning the unwrapped value on `recurringBilling.activate` method. 

At some point the right test should be implemented. Right now the test for this seems to be invalid since the result obtained through the test is an empty object and Shopify API's documentation says it should be returning the updated charge object.

[See RecurringApplicationCharge documentation](https://help.shopify.com/en/api/reference/billing/recurringapplicationcharge#activate)