### PR TITLE
[ts] Add option_values to variants

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1509,10 +1509,17 @@ declare namespace Shopify {
         updated_at: string;
     }
 
+    interface IProductVariantOption {
+        option_id: number;
+        name: string;
+        value: string
+    }
+
     type ProductVariantInventoryPolicy = "deny" | "continue";
     type ProductVariantWeightUnit = "g" | "kg" | "oz" | "lb";
 
     interface IProductVariant {
+        available: boolean;
         barcode: string;
         compare_at_price: string;
         created_at: string;
@@ -1525,6 +1532,7 @@ declare namespace Shopify {
         inventory_policy: ProductVariantInventoryPolicy;
         inventory_quantity: number;
         old_inventory_quantity: number;
+        option_values: IProductVariantOption[]
         option1: string | null;
         option2: string | null;
         option3: string | null;


### PR DESCRIPTION
See the poorly documented `options_values` field that is under View Response in [GET Product Listing](https://help.shopify.com/en/api/reference/sales_channels/productlisting#show).