### PR TITLE
partial implementation of resource-specific MetaFields

### DIFF
--- a/resources/blog.js
+++ b/resources/blog.js
@@ -16,6 +16,8 @@ function Blog(shopify) {
 
   this.name = 'blogs';
   this.key = 'blog';
+
+  this.metafield = new Metafield(shopify, this.name);
 }
 
 assign(Blog.prototype, base);

--- a/resources/blog.js
+++ b/resources/blog.js
@@ -4,6 +4,8 @@ const assign = require('lodash/assign');
 
 const base = require('../mixins/base');
 
+const Metafield = require('./resource-metafield');
+
 /**
  * Creates a Blog instance.
  *

--- a/resources/customer.js
+++ b/resources/customer.js
@@ -16,6 +16,8 @@ function Customer(shopify) {
 
   this.name = 'customers';
   this.key = 'customer';
+
+  this.metafield = new Metafield(shopify, this.name);
 }
 
 assign(Customer.prototype, base);

--- a/resources/customer.js
+++ b/resources/customer.js
@@ -4,6 +4,8 @@ const assign = require('lodash/assign');
 
 const base = require('../mixins/base');
 
+const Metafield = require('./resource-metafield');
+
 /**
  * Creates a Customer instance.
  *

--- a/resources/draft-order.js
+++ b/resources/draft-order.js
@@ -4,6 +4,8 @@ const assign = require('lodash/assign');
 
 const base = require('../mixins/base');
 
+const Metafield = require('./resource-metafield');
+
 /**
  * Creates a DraftOrder instance.
  *

--- a/resources/draft-order.js
+++ b/resources/draft-order.js
@@ -16,6 +16,8 @@ function DraftOrder(shopify) {
 
   this.name = 'draft_orders';
   this.key = 'draft_order';
+
+  this.metafield = new Metafield(shopify, this.name);
 }
 
 assign(DraftOrder.prototype, base);

--- a/resources/metafield.js
+++ b/resources/metafield.js
@@ -3,6 +3,7 @@
 const assign = require('lodash/assign');
 
 const base = require('../mixins/base');
+const baseChild = require('../mixins/base-child');
 
 /**
  * Creates a Metafield instance.

--- a/resources/order.js
+++ b/resources/order.js
@@ -4,6 +4,8 @@ const assign = require('lodash/assign');
 
 const base = require('../mixins/base');
 
+const Metafield = require('./resource-metafield');
+
 /**
  * Creates an Order instance.
  *
@@ -16,6 +18,8 @@ function Order(shopify) {
 
   this.name = 'orders';
   this.key = 'order';
+
+  this.metafield = new Metafield(shopify, this.name);
 }
 
 assign(Order.prototype, base);

--- a/resources/page.js
+++ b/resources/page.js
@@ -16,6 +16,8 @@ function Page(shopify) {
 
   this.name = 'pages';
   this.key = 'page';
+
+  this.metafield = new Metafield(shopify, this.name);
 }
 
 assign(Page.prototype, base);

--- a/resources/page.js
+++ b/resources/page.js
@@ -4,6 +4,8 @@ const assign = require('lodash/assign');
 
 const base = require('../mixins/base');
 
+const Metafield = require('./resource-metafield');
+
 /**
  * Creates a Page instance.
  *

--- a/resources/product.js
+++ b/resources/product.js
@@ -4,6 +4,8 @@ const assign = require('lodash/assign');
 
 const base = require('../mixins/base');
 
+const Metafield = require('./resource-metafield');
+
 /**
  * Creates a Product instance.
  *

--- a/resources/product.js
+++ b/resources/product.js
@@ -16,6 +16,8 @@ function Product(shopify) {
 
   this.name = 'products';
   this.key = 'product';
+
+  this.metafield = new Metafield(shopify, this.name);
 }
 
 assign(Product.prototype, base);

--- a/resources/resource-metafield.js
+++ b/resources/resource-metafield.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const assign = require('lodash/assign');
+const omit = require('lodash/omit');
+
+const base = require('../mixins/base');
+const baseChild = require('../mixins/base-child');
+
+// TODO: implement Metafields for following resources:
+// Article, Collection, Product Variant, Product Image
+
+/**
+ * Creates a ResourceMetafield instance.
+ *
+ * @param {Shopify} shopify Reference to the Shopify instance
+ * @constructor
+ * @public
+ */
+function ResourceMetafield(shopify, resourceName) {
+  this.shopify = shopify;
+
+  this.name = 'metafields';
+  this.key = 'metafield';
+  this.parentName = resourceName;
+}
+
+assign(ResourceMetafield.prototype, baseChild);
+
+module.exports = ResourceMetafield;


### PR DESCRIPTION
Partially implements #215.

Resource-specific Metafields can now be accessed using a nested ```metafield``` property on resources that follow the ```base-child``` url structure.

**Example**
```
return await shopifyClient.order.metafield
    .create(orderId, {param1: "metafieldValue"})
    .catch(onError);
```