### PR TITLE
Updates typescript definition for Orders to include additional fields

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1398,7 +1398,6 @@ declare namespace Shopify {
         processed_at: string;
         processing_method: OrderProcessingMethod;
         referring_site: string;
-        refunds: string;
         shipping_address: ICustomerAddress;
         shipping_lines: IOrderShippingLine[];
         subtotal_price: string;
@@ -1408,6 +1407,22 @@ declare namespace Shopify {
         total_tax: string;
         total_tip_received: string;
         total_weight: number;
+        token: string;
+        user_id: number | null;
+        updated_at: string;
+        order_status_url: string;
+        refunds: {
+          id: number;
+          order_id: number;
+          created_at: string;
+          note: string | null;
+          user_id: number | null;
+          processed_at: string;
+          restock: boolean;
+          refund_line_items: [];
+          transactions: [];
+          order_adjustments: [];
+        }[];
     }
 
     type OrderRisksRecommendation = "accept" | "cancel" | "cancel";

--- a/index.d.ts
+++ b/index.d.ts
@@ -1411,18 +1411,7 @@ declare namespace Shopify {
         user_id: number | null;
         updated_at: string;
         order_status_url: string;
-        refunds: {
-          id: number;
-          order_id: number;
-          created_at: string;
-          note: string | null;
-          user_id: number | null;
-          processed_at: string;
-          restock: boolean;
-          refund_line_items: [];
-          transactions: [];
-          order_adjustments: [];
-        }[];
+        refunds: IRefund[];
     }
 
     type OrderRisksRecommendation = "accept" | "cancel" | "cancel";


### PR DESCRIPTION
### Update TypeScript definitions to adjust fields returned from API for Orders

The following fields were not include in the `IOrder` interface and have been added:

- `token`
- `user_id`
- `updated_at`
- `order_status_url`

The definition had `refunds` listed as a string instead of an array and has been updated.