### PR TITLE
[ts] add order_status_url to IOrder type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1412,6 +1412,7 @@ declare namespace Shopify {
         updated_at: string;
         order_status_url: string;
         refunds: IRefund[];
+        order_status_url: string;
     }
 
     type OrderRisksRecommendation = "accept" | "cancel" | "cancel";


### PR DESCRIPTION
Documented in https://help.shopify.com/en/api/reference/orders/order#order-status-url-property