### PR TITLE
[ts] add confirmed to IOrder

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1372,6 +1372,7 @@ declare namespace Shopify {
         cart_token: string;
         client_details: IOrderClientDetails;
         closed_at: string | null;
+        confirmed: boolean;
         created_at: string;
         currency: string;
         customer: IOrderCustomer;


### PR DESCRIPTION
This is not explicitly documented but shows up in the documentation response object and in the wild.

See View Response at https://help.shopify.com/en/api/reference/orders/order#show