### PR TITLE
[ts] order_id should be a number

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1135,7 +1135,7 @@ declare namespace Shopify {
         latitude: string | null;
         longitude: string;
         message: string | null;
-        order_id: string;
+        order_id: number;
         province: string | null;
         shop_id: number;
         status: FulfillmentEventStatus;


### PR DESCRIPTION
As described in https://help.shopify.com/en/api/reference/shipping_and_fulfillment/fulfillmentevent#properties, `order_id` on fulfillment event is a number.