### PR TITLE
[ts] Update IRefund with ILineItem and order id

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1710,6 +1710,7 @@ declare namespace Shopify {
         restock: string;
         transactions: string;
         user_id: string;
+        order_id: number;
     }
 
     interface IReport {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1708,7 +1708,7 @@ declare namespace Shopify {
         note: string;
         refund_line_items: IRefundLineItem[];
         restock: string;
-        transactions: string;
+        transactions: ITransaction[];
         user_id: string;
         order_id: number;
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1188,6 +1188,50 @@ declare namespace Shopify {
       updated_at: string;
     }
 
+    type LineItemFulfillmentStatus = "fulfilled" | "partial" | null;
+
+    interface ILineItemProperty {
+        name: string;
+        value: string;
+    }
+
+    interface ILineItemDiscountAllocation {
+        amount: string;
+        discount_application_index: number;
+    }
+
+    interface ILineItemTaxLine {
+        title: string;
+        price: string;
+        rate: number;
+    }
+
+    interface ILineItem {
+        discount_allocations: ILineItemDiscountAllocation[];
+        fulfillable_quantity: number;
+        fulfillment_service: string;
+        fulfillment_status: LineItemFulfillmentStatus;
+        gift_card: boolean;
+        grams: number;
+        id: number;
+        name: string;
+        price: number;
+        product_id: number;
+        properties: ILineItemProperty[];
+        quantity: number;
+        require_shipping: boolean;
+        sku: string;
+        tax_lines: ILineItemTaxLine[];
+        taxable: boolean;
+        tip_payment_gateway: string;
+        tip_payment_method: string;
+        title: string;
+        total_discount: string;
+        variant_id: number;
+        variant_title: string;
+        vendor: string;
+    }
+
     interface ILocation {
         id: number;
         address1: string;
@@ -1652,9 +1696,9 @@ declare namespace Shopify {
 
     interface IRefundLineItem {
         id: number;
-        line_item: any;
+        line_item: ILineItem;
         lint_item_id: number;
-        quantity: 2;
+        quantity: number;
     }
 
     interface IRefund {


### PR DESCRIPTION
As described in https://help.shopify.com/en/api/reference/orders/order#line-items-property.

Was considering updating other object which also use this same object but have their own line items defined (`IOrder` -> `IOrderLineItem`, `IFulfillment` -> `IFulfillmentLineItem`, etc) but thought that might introduce a lot of breaking changes for people.