### PR TITLE
[ts] Fix ITransactionPaymentDetails credit_card_number

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1937,7 +1937,7 @@ declare namespace Shopify {
         avs_result_code: string | null;
         credit_card_bin: string | null;
         credit_card_company: string;
-        create_card_number: string;
+        credit_card_number: string;
         cvv_result_code: string | null;
     }
 


### PR DESCRIPTION
Fixed typo `create_card_number` should be `credit_card_number`.