### PR TITLE
added count params to types

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ shopify.metafield.create({
   - `update(id, params)`
 - customer
   - `accountActivationUrl(id)`
-  - `count()`
+  - `count([params])`
   - `create(params)`
   - `delete(id)`
   - `get(id[, params])`

--- a/index.d.ts
+++ b/index.d.ts
@@ -166,7 +166,7 @@ declare class Shopify {
   };
   customer: {
     accountActivationUrl: (id: number) => Promise<any>;
-    count: () => Promise<number>;
+    count: (params?: any) => Promise<number>;
     create: (params: any) => Promise<Shopify.ICustomer>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.ICustomer>;


### PR DESCRIPTION
Types definition is missing params available to the customer count request.