### PR TITLE
[api] Add optional params to inventoryLevels in the Location resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ shopify.metafield.create({
 - location
   - `count`
   - `get(id)`
-  - `inventoryLevels(id)`
+  - `inventoryLevels(id[, params])`
   - `list()`
 - marketingEvent
   - `count()`

--- a/index.d.ts
+++ b/index.d.ts
@@ -330,7 +330,7 @@ declare class Shopify {
   location: {
     count: () => Promise<number>;
     get: (id: number) => Promise<Shopify.ILocation>;
-    inventoryLevels: (id: number) => Promise<Shopify.IInventoryLevel[]>;
+    inventoryLevels: (id: number, params?: any) => Promise<Shopify.IInventoryLevel[]>;
     list: () => Promise<Shopify.ILocation[]>;
   };
   marketingEvent: {

--- a/resources/location.js
+++ b/resources/location.js
@@ -25,7 +25,7 @@ assign(Location.prototype, omit(base, ['create', 'delete', 'update']));
  * Retrieves a list of inventory levels for a location.
  *
  * @param {Number} id Location ID
- * @param {Object} [params] Optional query params
+ * @param {Object} [params] Query parameters
  * @return {Promise} Promise that resolves with the result
  * @public
  */

--- a/resources/location.js
+++ b/resources/location.js
@@ -25,6 +25,7 @@ assign(Location.prototype, omit(base, ['create', 'delete', 'update']));
  * Retrieves a list of inventory levels for a location.
  *
  * @param {Number} id Location ID
+ * @param {Object} [params] Optional query params
  * @return {Promise} Promise that resolves with the result
  * @public
  */

--- a/resources/location.js
+++ b/resources/location.js
@@ -28,9 +28,9 @@ assign(Location.prototype, omit(base, ['create', 'delete', 'update']));
  * @return {Promise} Promise that resolves with the result
  * @public
  */
-Location.prototype.inventoryLevels = function inventoryLevels(id) {
+Location.prototype.inventoryLevels = function inventoryLevels(id, params) {
   const key = 'inventory_levels';
-  const url = this.buildUrl(`${id}/${key}`);
+  const url = this.buildUrl(`${id}/${key}`, params);
   return this.shopify.request(url, 'GET', key);
 };
 

--- a/test/location.test.js
+++ b/test/location.test.js
@@ -44,7 +44,7 @@ describe('Shopify#location', () => {
       .then(data => expect(data).to.equal(4));
   });
 
-  it('gets a list of inventory levels for a location', () => {
+  it('gets a list of inventory levels for a location (1/2)', () => {
     const output = fixtures.res.inventoryLevels;
 
     scope
@@ -52,6 +52,17 @@ describe('Shopify#location', () => {
       .reply(200, output);
 
     return shopify.location.inventoryLevels(487838322)
+      .then(data => expect(data).to.deep.equal(output.inventory_levels));
+  });
+
+  it('gets a list of inventory levels for a location (2/2)', () => {
+    const output = fixtures.res.inventoryLevels;
+
+    scope
+      .get('/admin/locations/487838322/inventory_levels.json?limit=50')
+      .reply(200, output);
+
+    return shopify.location.inventoryLevels(487838322, { limit: 50 })
       .then(data => expect(data).to.deep.equal(output.inventory_levels));
   });
 });


### PR DESCRIPTION
Unfortunately, the params are undocumented in https://help.shopify.com/en/api/reference/inventory/location#inventory_levels but this resource does indeed take query params including `limit` and `page`, which are crucial if one is getting inventory levels for a location that has many product variants/inventory items.