### PR TITLE
Add missing type definition for storefrontAccessToken

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -542,6 +542,11 @@ declare class Shopify {
     products: (id: number, params: any) => Promise<Shopify.IProduct>;
     update: (id: number, params: any) => Promise<Shopify.ISmartCollection>;
   };
+  storefrontAccessToken: {
+    create: (params: any) => Promise<Shopify.IStorefrontAccessToken>;
+    delete: (id: number) => Promise<void>;
+    list: () => Promise<Shopify.IStorefrontAccessToken[]>;
+  };
   tenderTransaction: {
     list: (params?: any) => Promise<Shopify.ITenderTransaction[]>;
   };


### PR DESCRIPTION
There was no definition for storefrontAccessToken despite there being a interface for IStorefrontToken. This PR adds this definition and allows Typescript to recognise the methods in storefrontAccessToken.