### PR TITLE
Add source_identifier to Order interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1904,6 +1904,7 @@ declare namespace Shopify {
     refunds: IRefund[];
     shipping_address: ICustomerAddress;
     shipping_lines: IOrderShippingLine[];
+    source_identifier: string | null;
     source_name: 'web' | 'pos' | 'shopify_draft_order' | 'iphone' | 'android';
     subtotal_price: string;
     subtotal_price_set: IOrderAdjustmentAmountSet;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1905,7 +1905,7 @@ declare namespace Shopify {
     shipping_address: ICustomerAddress;
     shipping_lines: IOrderShippingLine[];
     source_identifier: string | null;
-    source_name: 'web' | 'pos' | 'shopify_draft_order' | 'iphone' | 'android';
+    source_name: 'web' | 'pos' | 'shopify_draft_order' | 'iphone' | 'android' | string;
     subtotal_price: string;
     subtotal_price_set: IOrderAdjustmentAmountSet;
     tags: string;


### PR DESCRIPTION
Order is missing the property source_identifier when using this node_module in Typescript. This PR will add the missing property to the interface.