### PR TITLE
Update types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2197,7 +2197,7 @@ declare namespace Shopify {
   }
 
   interface IOrderAdjustmentMoney {
-    amount: number;
+    amount: number | string;
     currency_code: string;
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1727,7 +1727,11 @@ declare namespace Shopify {
     | 'pending'
     | 'refunded'
     | 'voided';
-  type OrderFulfillmentStatus = 'fulfilled' | 'partial' | null;
+  type OrderFulfillmentStatus =
+    | 'fulfilled'
+    | 'partial'
+    | 'restocked'
+    | null;
   type OrderProcessingMethod =
     | 'checkout'
     | 'direct'

--- a/index.d.ts
+++ b/index.d.ts
@@ -1725,6 +1725,7 @@ declare namespace Shopify {
     | 'partially_paid'
     | 'partially_refunded'
     | 'pending'
+    | 'refunded'
     | 'voided';
   type OrderFulfillmentStatus = 'fulfilled' | 'partial' | null;
   type OrderProcessingMethod =


### PR DESCRIPTION
* `OrderFinancialStatus` was missing `refunded`
* `OrderFulfillmentStatus` was missing `restocked`
* `IOrderAdjustmentMoney` had `amount: number`, but everything i'm seeing in the documentation as well as in the API responses, this value is a `string`. I added it as an OR because I didn't want to cause any breaking changes for anyone depending on that property being a number for whatever reason.