### PR TITLE
[ts] Revise interface ILineItem

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1544,7 +1544,7 @@ declare namespace Shopify {
     updated_at: string;
   }
 
-  type LineItemFulfillmentStatus = 'fulfilled' | 'partial' | null;
+  type LineItemFulfillmentStatus = 'fulfilled' | 'not_eligible' | 'partial' | null;
 
   interface ILineItemProperty {
     name: string;
@@ -1572,7 +1572,7 @@ declare namespace Shopify {
     grams: number;
     id: number;
     name: string;
-    price: number;
+    price: string;
     price_set: IOrderAdjustmentAmountSet;
     product_id: number;
     properties: ILineItemProperty[];


### PR DESCRIPTION
price should be a string
add `not_eligible` to possible values of fulfillment status
ref: https://help.shopify.com/en/api/reference/orders/order#line-items-property