### PR TITLE
[ts] Add missing properties to IFulfillmentService

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1486,13 +1486,17 @@ declare namespace Shopify {
 
   interface IFulfillmentService {
     callback_url: string;
+    email: string | null;
     format: 'json';
     handle: string;
+    id: number;
+    include_pending_stock: boolean;
     inventory_management: boolean;
     location_id: number;
     name: string;
     provider_id: number | null;
     requires_shipping_method: boolean;
+    service_name: string | null;
     tracking_support: boolean;
   }
 


### PR DESCRIPTION
These are partially undocumented properties that are not yet listed in the main table of properties here: https://help.shopify.com/en/api/reference/shipping-and-fulfillment/fulfillmentservice#properties

But these properties are returned with the api calls to this endpoint, and are documented in the response objects on that same page: https://help.shopify.com/en/api/reference/shipping-and-fulfillment/fulfillmentservice#index