### PR TITLE
[api] Add support for optional Shopify API version

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ configuration options.
   with the `apiKey` and `password` options. If you are looking for a premade
   solution to obtain an access token, take a look at the [shopify-token][]
   module.
+- `apiVersion` - Optional - A string to specify the [Shopify API version](https://help.shopify.com/en/api/versioning) to use for requests
 - `autoLimit` - Optional - This option allows you to regulate the request rate
   in order to avoid hitting the [rate limit][api-call-limit]. Requests are
   limited using the token bucket algorithm. Accepted values are a boolean or a

--- a/index.d.ts
+++ b/index.d.ts
@@ -612,6 +612,7 @@ declare namespace Shopify {
 
   export interface IPublicShopifyConfig {
     accessToken: string;
+    apiVersion?: string;
     autoLimit?: boolean | IAutoLimit;
     shopName: string;
     timeout?: number;
@@ -619,6 +620,7 @@ declare namespace Shopify {
 
   export interface IPrivateShopifyConfig {
     apiKey: string;
+    apiVersion?: string;
     autoLimit?: boolean | IAutoLimit;
     password: string;
     shopName: string;

--- a/index.js
+++ b/index.js
@@ -164,7 +164,15 @@ Shopify.prototype.updateGqlLimits = function updateGqlLimits(throttle) {
  * @public
  */
 Shopify.prototype.graphql = function graphql(data) {
-  const url = assign({ path: '/admin/api/graphql.json' }, this.baseUrl);
+  let path = '/admin/api';
+
+  if (this.options.apiVersion) {
+    path += '/' + this.options.apiVersion;
+  }
+
+  path += '/graphql.json';
+
+  const url = assign({ path: path }, this.baseUrl);
   const options = assign({
     headers: {
       'User-Agent': `${pkg.name}/${pkg.version}`,

--- a/index.js
+++ b/index.js
@@ -107,12 +107,6 @@ Shopify.prototype.request = function request(url, method, key, params) {
     method
   }, url);
 
-  if (this.options.apiVersion) {
-    if (options.path.startsWith('/admin/') && !options.path.startsWith('/admin/api/')) {
-      options.path = `/admin/api/${this.options.apiVersion}/${options.path.slice(7)}`;
-    }
-  }
-
   if (this.options.accessToken) {
     options.headers['X-Shopify-Access-Token'] = this.options.accessToken;
   }

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ const pkg = require('./package');
  * @param {String} options.apiKey The API Key
  * @param {String} options.password The private app password
  * @param {String} options.accessToken The persistent OAuth public app token
+ * @param {String} [options.apiVersion] The Shopify API version to use
  * @param {Boolean|Object} [options.autoLimit] Limits the request rate
  * @param {Number} [options.timeout] The request timeout
  * @constructor
@@ -105,6 +106,12 @@ Shopify.prototype.request = function request(url, method, key, params) {
     retries: 0,
     method
   }, url);
+
+  if (this.options.apiVersion) {
+    if (options.path.startsWith('/admin/') && !options.path.startsWith('/admin/api/')) {
+      options.path = `/admin/api/${this.options.apiVersion}/${options.path.slice(7)}`;
+    }
+  }
 
   if (this.options.accessToken) {
     options.headers['X-Shopify-Access-Token'] = this.options.accessToken;

--- a/mixins/base-child.js
+++ b/mixins/base-child.js
@@ -108,6 +108,10 @@ const baseChild = {
       .replace(/\/+/g, '/')
       .replace(/\/$/, '');
 
+    if (this.shopify.options.apiVersion) {
+      path = `/admin/api/${this.shopify.options.apiVersion}/${path.slice(7)}`;
+    }
+
     path += '.json';
 
     if (query) path += '?' + qs.stringify(query, { arrayFormat: 'brackets' });

--- a/mixins/base-child.js
+++ b/mixins/base-child.js
@@ -104,14 +104,14 @@ const baseChild = {
   buildUrl(parentId, id, query) {
     id || id === 0 || (id = '');
 
-    let path = `/admin/${this.parentName}/${parentId}/${this.name}/${id}`
-      .replace(/\/+/g, '/')
-      .replace(/\/$/, '');
+    let path = '/admin';
 
     if (this.shopify.options.apiVersion) {
-      path = `/admin/api/${this.shopify.options.apiVersion}/${path.slice(7)}`;
+      path += `/api/${this.shopify.options.apiVersion}`;
     }
 
+    path += `/${this.parentName}/${parentId}/${this.name}/${id}`;
+    path = path.replace(/\/+/g, '/').replace(/\/$/, '');
     path += '.json';
 
     if (query) path += '?' + qs.stringify(query, { arrayFormat: 'brackets' });

--- a/mixins/base.js
+++ b/mixins/base.js
@@ -100,6 +100,10 @@ const base = {
       .replace(/\/+/g, '/')
       .replace(/\/$/, '');
 
+    if (this.shopify.options.apiVersion) {
+      path = `/admin/api/${this.shopify.options.apiVersion}/${path.slice(7)}`;
+    }
+
     path += '.json';
 
     if (query) path += '?' + qs.stringify(query, { arrayFormat: 'brackets' });

--- a/mixins/base.js
+++ b/mixins/base.js
@@ -99,7 +99,7 @@ const base = {
     let path = '/admin';
 
     if (this.shopify.options.apiVersion) {
-      path = `/api/${this.shopify.options.apiVersion}`;
+      path += `/api/${this.shopify.options.apiVersion}`;
     }
 
     path += `/${this.name}/${id}`;

--- a/mixins/base.js
+++ b/mixins/base.js
@@ -96,14 +96,14 @@ const base = {
   buildUrl(id, query) {
     id || id === 0 || (id = '');
 
-    let path = `/admin/${this.name}/${id}`
-      .replace(/\/+/g, '/')
-      .replace(/\/$/, '');
+    let path = '/admin';
 
     if (this.shopify.options.apiVersion) {
-      path = `/admin/api/${this.shopify.options.apiVersion}/${path.slice(7)}`;
+      path = `/api/${this.shopify.options.apiVersion}`;
     }
 
+    path += `/${this.name}/${id}`;
+    path = path.replace(/\/+/g, '/').replace(/\/$/, '');
     path += '.json';
 
     if (query) path += '?' + qs.stringify(query, { arrayFormat: 'brackets' });

--- a/mixins/shopify-payments.js
+++ b/mixins/shopify-payments.js
@@ -21,10 +21,14 @@ const shopifyPayments = {
   buildUrl(id, query) {
     id || id === 0 || (id = '');
 
-    let path = `/admin/shopify_payments/${this.name}/${id}`
-      .replace(/\/+/g, '/')
-      .replace(/\/$/, '');
+    let path = '/admin';
 
+    if (this.shopify.options.apiVersion) {
+      path += `/api/${this.shopify.options.apiVersion}`;
+    }
+
+    path += `/shopify_payments/${this.name}/${id}`;
+    path = path.replace(/\/+/g, '/').replace(/\/$/, '');
     path += '.json';
 
     if (query) path += '?' + qs.stringify(query, { arrayFormat: 'brackets' });

--- a/resources/fulfillment-event.js
+++ b/resources/fulfillment-event.js
@@ -104,8 +104,16 @@ FulfillmentEvent.prototype.delete = function remove(orderId, fulfillmentId, id) 
 FulfillmentEvent.prototype.buildUrl = function buildUrl(orderId, fulfillmentId, id, query) {
   id || id === 0 || (id = '');
 
+  let base_url = '/admin';
+
+  if (this.shopify.options.apiVersion) {
+    base_url += `/api/${this.shopify.options.apiVersion}`;
+  }
+
+  base_url += '/orders';
+
   let path = [
-    '/admin/orders',
+    base_url,
     orderId,
     this.parentName,
     fulfillmentId,

--- a/test/common.js
+++ b/test/common.js
@@ -8,6 +8,7 @@ const Shopify = require('..');
 const accessToken = 'f85632530bf277ec9ac6f649fc327f17';
 const password = '72297d971271bc62ca899bba7432acb1';
 const apiKey = 'bc731e500840231da5b43bb3f388d2f0';
+const apiVersion = '2019-04';
 const shopName ='johns-apparel';
 
 const shopify = new Shopify({ shopName, accessToken });
@@ -26,5 +27,6 @@ module.exports = {
   shopName,
   shopify,
   apiKey,
+  apiVersion,
   scope
 };

--- a/test/fulfillment-event.test.js
+++ b/test/fulfillment-event.test.js
@@ -5,9 +5,14 @@ describe('Shopify#fulfillmentEvent', () => {
 
   const fixtures = require('./fixtures/fulfillment-event');
   const common = require('./common');
+  const Shopify = require('..');
 
   const shopify = common.shopify;
   const scope = common.scope;
+
+  const accessToken = common.accessToken;
+  const shopName = common.shopName;
+  const apiVersion = common.apiVersion;
 
   afterEach(() => expect(scope.isDone()).to.be.true);
 
@@ -75,5 +80,15 @@ describe('Shopify#fulfillmentEvent', () => {
 
     return shopify.fulfillmentEvent.delete(450789469, 255858046, 2)
       .then(data => expect(data).to.deep.equal({}));
+  });
+
+  it('injects the api version to the request path if provided', () => {
+    const shopify = new Shopify({ shopName, accessToken, apiVersion });
+
+    scope
+      .delete(`/admin/api/${apiVersion}/orders/450789469/fulfillments/255858046/events/2.json`)
+      .reply(200, {});
+
+    return shopify.fulfillmentEvent.delete(450789469, 255858046, 2);
   });
 });

--- a/test/fulfillment-event.test.js
+++ b/test/fulfillment-event.test.js
@@ -89,6 +89,7 @@ describe('Shopify#fulfillmentEvent', () => {
       .delete(`/admin/api/${apiVersion}/orders/450789469/fulfillments/255858046/events/2.json`)
       .reply(200, {});
 
-    return shopify.fulfillmentEvent.delete(450789469, 255858046, 2);
+    return shopify.fulfillmentEvent.delete(450789469, 255858046, 2)
+      .then(data => expect(data).to.deep.equal({}));
   });
 });

--- a/test/fulfillment.test.js
+++ b/test/fulfillment.test.js
@@ -5,9 +5,14 @@ describe('Shopify#fulfillment', () => {
 
   const fixtures = require('./fixtures/fulfillment');
   const common = require('./common');
+  const Shopify = require('..');
 
   const shopify = common.shopify;
   const scope = common.scope;
+
+  const accessToken = common.accessToken;
+  const shopName = common.shopName;
+  const apiVersion = common.apiVersion;
 
   afterEach(() => expect(scope.isDone()).to.be.true);
 
@@ -128,5 +133,15 @@ describe('Shopify#fulfillment', () => {
 
     return shopify.fulfillment.cancel(450789469, 255858046)
       .then(data => expect(data).to.deep.equal(output.fulfillment));
+  });
+
+  it('injects the api version to the request path if provided', () => {
+    scope
+      .get(`/admin/api/${apiVersion}/orders/450789469/fulfillments/count.json`)
+      .reply(200, { count: 1 });
+
+    const shopify = new Shopify({ shopName, accessToken, apiVersion });
+
+    return shopify.fulfillment.count(450789469);
   });
 });

--- a/test/fulfillment.test.js
+++ b/test/fulfillment.test.js
@@ -142,6 +142,7 @@ describe('Shopify#fulfillment', () => {
 
     const shopify = new Shopify({ shopName, accessToken, apiVersion });
 
-    return shopify.fulfillment.count(450789469);
+    return shopify.fulfillment.count(450789469)
+      .then(data => expect(data).to.equal(1));
   });
 });

--- a/test/payout.test.js
+++ b/test/payout.test.js
@@ -5,9 +5,14 @@ describe('Shopify#payout', () => {
 
   const fixtures = require('./fixtures/payout');
   const common = require('./common');
+  const Shopify = require('..');
 
   const shopify = common.shopify;
   const scope = common.scope;
+
+  const accessToken = common.accessToken;
+  const shopName = common.shopName;
+  const apiVersion = common.apiVersion;
 
   afterEach(() => expect(scope.isDone()).to.be.true);
 
@@ -42,5 +47,16 @@ describe('Shopify#payout', () => {
 
     return shopify.payout.get(623721858)
       .then(data => expect(data).to.deep.equal(output.payout));
+  });
+
+  it('injects the api version to the request path if provided', () => {
+    const output = fixtures.res.get;
+    const shopify = new Shopify({ shopName, accessToken, apiVersion });
+
+    scope
+      .get(`/admin/api/${apiVersion}/shopify_payments/payouts/623721858.json`)
+      .reply(200, output);
+
+    return shopify.payout.get(623721858);
   });
 });

--- a/test/payout.test.js
+++ b/test/payout.test.js
@@ -57,6 +57,7 @@ describe('Shopify#payout', () => {
       .get(`/admin/api/${apiVersion}/shopify_payments/payouts/623721858.json`)
       .reply(200, output);
 
-    return shopify.payout.get(623721858);
+    return shopify.payout.get(623721858)
+      .then(data => expect(data).to.deep.equal(output.payout));
   });
 });

--- a/test/shop.test.js
+++ b/test/shop.test.js
@@ -5,9 +5,14 @@ describe('Shopify#shop', () => {
 
   const fixtures = require('./fixtures/shop');
   const common = require('./common');
+  const Shopify = require('..');
 
   const shopify = common.shopify;
   const scope = common.scope;
+
+  const accessToken = common.accessToken;
+  const shopName = common.shopName;
+  const apiVersion = common.apiVersion;
 
   afterEach(() => expect(scope.isDone()).to.be.true);
 
@@ -31,5 +36,15 @@ describe('Shopify#shop', () => {
 
     return shopify.shop.get({ foo: 'bar' })
       .then(data => expect(data).to.deep.equal(output.shop));
+  });
+
+  it('injects the api version to the request path if provided', () => {
+    const shopify = new Shopify({ shopName, accessToken, apiVersion });
+
+    scope
+      .get(`/admin/api/${apiVersion}/shop.json`)
+      .reply(200, { status: 'success' });
+
+    return shopify.shop.get();
   });
 });

--- a/test/shopify.test.js
+++ b/test/shopify.test.js
@@ -16,6 +16,7 @@ describe('Shopify', () => {
   const password = common.password;
   const shopify = common.shopify;
   const apiKey = common.apiKey;
+  const apiVersion = common.apiVersion;
 
   it('exports the constructor', () => {
     expect(Shopify).to.be.a('function');
@@ -535,6 +536,21 @@ describe('Shopify', () => {
 
       scope
         .post(path)
+        .reply(200, response);
+
+      return shopify.graphql(dummyData)
+        .then(res => expect(res).to.deep.equal(response.data));
+    });
+
+    it('injects the api version to the request path if provided', () => {
+      const shopify = new Shopify({ shopName, accessToken, apiVersion });
+
+      const response = {
+        data: { foo: 'bar' }
+      };
+
+      scope
+        .post(`/admin/api/${apiVersion}/graphql.json`)
         .reply(200, response);
 
       return shopify.graphql(dummyData)

--- a/test/shopify.test.js
+++ b/test/shopify.test.js
@@ -16,7 +16,6 @@ describe('Shopify', () => {
   const password = common.password;
   const shopify = common.shopify;
   const apiKey = common.apiKey;
-  const apiVersion = common.apiVersion;
 
   it('exports the constructor', () => {
     expect(Shopify).to.be.a('function');
@@ -302,55 +301,6 @@ describe('Shopify', () => {
             max: 40
           });
         });
-    });
-
-    // Test base mixin
-    it('injects the api version to the path if provided (1/4)', () => {
-      const shopify = new Shopify({ shopName, accessToken, apiVersion });
-
-      scope
-        .get(`/admin/api/${apiVersion}/shop.json`)
-        .reply(200, { status: 'success' });
-
-      return shopify.shop.get();
-    });
-
-    // Test base-children mixin
-    it('injects the api version to the path if provided (2/4)', () => {
-      scope
-        .get(`/admin/api/${apiVersion}/orders/450789469/fulfillments/count.json`)
-        .reply(200, { count: 1 });
-
-      const shopify = new Shopify({ shopName, accessToken, apiVersion });
-
-      return shopify.fulfillment.count(450789469)
-        .then(data => expect(data).to.equal(1));
-    });
-
-    // Test shopify-payment mixin
-    it('injects the api version to the path if provided (3/4)', () => {
-      const paymentFixtures = require('./fixtures/payout');
-      const output = paymentFixtures.res.get;
-      const shopify = new Shopify({ shopName, accessToken, apiVersion });
-
-      scope
-        .get(`/admin/api/${apiVersion}/shopify_payments/payouts/623721858.json`)
-        .reply(200, output);
-
-      return shopify.payout.get(623721858)
-        .then(data => expect(data).to.deep.equal(output.payout));
-    });
-
-    // Test fulfillment-events
-    it('injects the api version to the path if provided (4/4)', () => {
-      const shopify = new Shopify({ shopName, accessToken, apiVersion });
-
-      scope
-        .delete(`/admin/api/${apiVersion}/orders/450789469/fulfillments/255858046/events/2.json`)
-        .reply(200, {});
-
-      return shopify.fulfillmentEvent.delete(450789469, 255858046, 2)
-        .then(data => expect(data).to.deep.equal({}));
     });
 
     it('returns the subtree with root node at key', () => {

--- a/test/shopify.test.js
+++ b/test/shopify.test.js
@@ -16,6 +16,7 @@ describe('Shopify', () => {
   const password = common.password;
   const shopify = common.shopify;
   const apiKey = common.apiKey;
+  const apiVersion = common.apiVersion;
 
   it('exports the constructor', () => {
     expect(Shopify).to.be.a('function');
@@ -301,6 +302,55 @@ describe('Shopify', () => {
             max: 40
           });
         });
+    });
+
+    // Test base mixin
+    it('injects the api version to the path if provided (1/4)', () => {
+      const shopify = new Shopify({ shopName, accessToken, apiVersion });
+
+      scope
+        .get(`/admin/api/${apiVersion}/shop.json`)
+        .reply(200, { status: 'success' });
+
+      return shopify.shop.get();
+    });
+
+    // Test base-children mixin
+    it('injects the api version to the path if provided (2/4)', () => {
+      scope
+        .get(`/admin/api/${apiVersion}/orders/450789469/fulfillments/count.json`)
+        .reply(200, { count: 1 });
+
+      const shopify = new Shopify({ shopName, accessToken, apiVersion });
+
+      return shopify.fulfillment.count(450789469)
+        .then(data => expect(data).to.equal(1));
+    });
+
+    // Test shopify-payment mixin
+    it('injects the api version to the path if provided (3/4)', () => {
+      const paymentFixtures = require('./fixtures/payout');
+      const output = paymentFixtures.res.get;
+      const shopify = new Shopify({ shopName, accessToken, apiVersion });
+
+      scope
+        .get(`/admin/api/${apiVersion}/shopify_payments/payouts/623721858.json`)
+        .reply(200, output);
+
+      return shopify.payout.get(623721858)
+        .then(data => expect(data).to.deep.equal(output.payout));
+    });
+
+    // Test fulfillment-events
+    it('injects the api version to the path if provided (4/4)', () => {
+      const shopify = new Shopify({ shopName, accessToken, apiVersion });
+
+      scope
+        .delete(`/admin/api/${apiVersion}/orders/450789469/fulfillments/255858046/events/2.json`)
+        .reply(200, {});
+
+      return shopify.fulfillmentEvent.delete(450789469, 255858046, 2)
+        .then(data => expect(data).to.deep.equal({}));
     });
 
     it('returns the subtree with root node at key', () => {


### PR DESCRIPTION
This is just super basic, but it gets the job done. I don't have any tests for it or anything. Feel free to make changes or suggestions. I'm not sure if the request URLs always start with `/admin/`, but if they do, that part can be optimized. 