### PR TITLE
Add Option for Including Presentment Prices Header

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,15 +114,10 @@ Shopify.prototype.request = function request(url, method, key, params) {
     method
   }, url);
 
+  options.headers['User-Agent'] = `${pkg.name}/${pkg.version}`;
+
   if (this.options.accessToken) {
     options.headers['X-Shopify-Access-Token'] = this.options.accessToken;
-  }
-
-  if (this.options.presentmentPrices
-    && /(product(?!_)|variant|product_listing)[s]*/.test(key)
-    && !url.path.includes('smart_collection')
-    && method === 'GET') {
-    options.headers['X-Shopify-Api-Features'] = 'include-presentment-prices';
   }
 
   if (params) {

--- a/index.js
+++ b/index.js
@@ -22,8 +22,8 @@ const pkg = require('./package');
  * @param {String} options.password The private app password
  * @param {String} options.accessToken The persistent OAuth public app token
  * @param {String} [options.apiVersion] The Shopify API version to use
- * @param {Boolean} [options.presentmentPrices] Whether to include the header
- *   to pull presentment prices for products
+ * @param {Boolean} [options.presentmentPrices] Whether to include the header to
+ *     pull presentment prices for products
  * @param {Boolean|Object} [options.autoLimit] Limits the request rate
  * @param {Number} [options.timeout] The request timeout
  * @constructor
@@ -59,6 +59,7 @@ function Shopify(options) {
 
   this.baseUrl = {
     auth: !options.accessToken && `${options.apiKey}:${options.password}`,
+    headers: {},
     hostname: !options.shopName.endsWith('.myshopify.com')
       ? `${options.shopName}.myshopify.com`
       : options.shopName,
@@ -73,12 +74,6 @@ function Shopify(options) {
 
     this.request = stopcock(this.request, conf);
   }
-
-  this.presentmentHeader = {
-    headers: {
-      ['X-Shopify-Api-Features']: 'include-presentment-prices'
-    }
-  };
 }
 
 Object.setPrototypeOf(Shopify.prototype, EventEmitter.prototype);
@@ -114,7 +109,6 @@ Shopify.prototype.updateLimits = function updateLimits(header) {
  */
 Shopify.prototype.request = function request(url, method, key, params) {
   const options = assign({
-    headers: {},
     timeout: this.options.timeout,
     json: true,
     retries: 0,
@@ -182,17 +176,16 @@ Shopify.prototype.graphql = function graphql(data) {
 
   path += '/graphql.json';
 
-  const url = assign({ path: path }, this.baseUrl);
+  const url = assign({ path }, this.baseUrl);
   const options = assign({
-    headers: {
-      'User-Agent': `${pkg.name}/${pkg.version}`,
-      'Content-Type': 'application/graphql'
-    },
     timeout: this.options.timeout,
     retries: 0,
     method: 'POST',
     body: data
   }, url);
+
+  options.headers['User-Agent'] = `${pkg.name}/${pkg.version}`;
+  options.headers['Content-Type'] = 'application/graphql';
 
   if (this.options.accessToken) {
     options.headers['X-Shopify-Access-Token'] = this.options.accessToken;
@@ -212,6 +205,7 @@ Shopify.prototype.graphql = function graphql(data) {
     if (res.body.extensions && res.body.extensions.cost) {
       this.updateGqlLimits(res.body.extensions.cost.throttleStatus);
     }
+
     return res.body.data || {};
   });
 };

--- a/index.js
+++ b/index.js
@@ -16,12 +16,13 @@ const pkg = require('./package');
 /**
  * Creates a Shopify instance.
  *
- * @param {Object} options Configuration options
+ * @param {{presentmentPrices: boolean, shopName: string, accessToken: string}} options Configuration options
  * @param {String} options.shopName The name of the shop
  * @param {String} options.apiKey The API Key
  * @param {String} options.password The private app password
  * @param {String} options.accessToken The persistent OAuth public app token
  * @param {String} [options.apiVersion] The Shopify API version to use
+ * @param {Boolean} [options.presentmentPrices] Whether to include the header to pull presentment prices for products
  * @param {Boolean|Object} [options.autoLimit] Limits the request rate
  * @param {Number} [options.timeout] The request timeout
  * @constructor
@@ -115,6 +116,10 @@ Shopify.prototype.request = function request(url, method, key, params) {
 
   if (this.options.accessToken) {
     options.headers['X-Shopify-Access-Token'] = this.options.accessToken;
+  }
+
+  if (this.options.presentmentPrices) {
+    options.headers['X-Shopify-Api-Features'] = 'include-presentment-prices';
   }
 
   if (params) {

--- a/index.js
+++ b/index.js
@@ -118,7 +118,10 @@ Shopify.prototype.request = function request(url, method, key, params) {
     options.headers['X-Shopify-Access-Token'] = this.options.accessToken;
   }
 
-  if (this.options.presentmentPrices) {
+  if (this.options.presentmentPrices
+    && /(product(?!_)|variant|product_listing)[s]*/.test(key)
+    && !url.path.includes('smart_collection')
+    && method === 'GET') {
     options.headers['X-Shopify-Api-Features'] = 'include-presentment-prices';
   }
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const pkg = require('./package');
 /**
  * Creates a Shopify instance.
  *
- * @param {{presentmentPrices: boolean, shopName: string, accessToken: string}} options Configuration options
+ * @param {Object} options Configuration options
  * @param {String} options.shopName The name of the shop
  * @param {String} options.apiKey The API Key
  * @param {String} options.password The private app password

--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ const pkg = require('./package');
  * @param {String} options.password The private app password
  * @param {String} options.accessToken The persistent OAuth public app token
  * @param {String} [options.apiVersion] The Shopify API version to use
- * @param {Boolean} [options.presentmentPrices] Whether to include the header to pull presentment prices for products
+ * @param {Boolean} [options.presentmentPrices] Whether to include the header
+ *   to pull presentment prices for products
  * @param {Boolean|Object} [options.autoLimit] Limits the request rate
  * @param {Number} [options.timeout] The request timeout
  * @constructor
@@ -72,6 +73,12 @@ function Shopify(options) {
 
     this.request = stopcock(this.request, conf);
   }
+
+  this.presentmentHeader = {
+    headers: {
+      ['X-Shopify-Api-Features']: 'include-presentment-prices'
+    }
+  };
 }
 
 Object.setPrototypeOf(Shopify.prototype, EventEmitter.prototype);
@@ -107,7 +114,7 @@ Shopify.prototype.updateLimits = function updateLimits(header) {
  */
 Shopify.prototype.request = function request(url, method, key, params) {
   const options = assign({
-    headers: { 'User-Agent': `${pkg.name}/${pkg.version}` },
+    headers: {},
     timeout: this.options.timeout,
     json: true,
     retries: 0,
@@ -162,7 +169,7 @@ Shopify.prototype.updateGqlLimits = function updateGqlLimits(throttle) {
 /**
  * Sends a request to the Shopify GraphQL API endpoint.
  *
- * @param string [data] Request body
+ * @param {String} [data] Request body
  * @return {Promise}
  * @public
  */

--- a/resources/product-listing.js
+++ b/resources/product-listing.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const assign = require('lodash/assign');
-const omit = require('lodash/omit');
+const pick = require('lodash/pick');
 
 const base = require('../mixins/base');
 
@@ -19,37 +19,45 @@ function ProductListing(shopify) {
   this.key = 'product_listing';
 }
 
-assign(ProductListing.prototype, omit(base, ['create', 'update', 'buildUrl', 'productIds', 'count', 'delete']));
+assign(ProductListing.prototype, pick(base, ['count', 'buildUrl', 'delete']));
 
 /**
- * Builds the request URL.
+ * Gets a single record by its ID.
  *
- * @param {Number|String} [id] Record ID
- * @param {Object} [query] Query parameters
- * @return {Object} URL object
- * @private
- */
-ProductListing.prototype.buildUrl = function(id, query) {
-  const baseUrl = base.buildUrl.call(this, id, query);
-
-  if (this.shopify.options.presentmentPrices) {
-    baseUrl.headers = { ['X-Shopify-Api-Features']: 'include-presentment-prices' };
-  }
-
-  return baseUrl;
-};
-
-/**
- * Counts the number of records.
- *
+ * @param {Number} id Record ID
  * @param {Object} [params] Query parameters
  * @return {Promise} Promise that resolves with the result
  * @public
  */
-ProductListing.prototype.count = function(params) {
-  const key = 'count';
-  const url = base.buildUrl.call(this, key, params);
-  return this.shopify.request(url, 'GET', key);
+ProductListing.prototype.get = function(id, params) {
+  const url = this.buildUrl(id, params);
+
+  if (this.shopify.options.presentmentPrices) {
+    url.headers = {
+      ['X-Shopify-Api-Features']: 'include-presentment-prices'
+    };
+  }
+
+  return this.shopify.request(url, 'GET', this.key);
+};
+
+/**
+ * Gets a list of records.
+ *
+ * @param {Object} params Query parameters
+ * @return {Promise} Promise that resolves with the result
+ * @public
+ */
+ProductListing.prototype.list = function(params) {
+  const url = this.buildUrl(undefined, params);
+
+  if (this.shopify.options.presentmentPrices) {
+    url.headers = {
+      ['X-Shopify-Api-Features']: 'include-presentment-prices'
+    };
+  }
+
+  return this.shopify.request(url, 'GET', this.name);
 };
 
 /**
@@ -62,20 +70,13 @@ ProductListing.prototype.count = function(params) {
  */
 ProductListing.prototype.create = function create(productId, params) {
   params || (params = { product_id: productId });
-  const url = this.buildUrl(productId);
-  return this.shopify.request(url, 'PUT', this.key, params);
-};
+  let url = this.buildUrl(productId);
 
-/**
- * Deletes a record.
- *
- * @param {Number} id Record ID
- * @return {Promise} Promise that resolves with the result
- * @public
- */
-ProductListing.prototype.delete = function(id) {
-  const url = base.buildUrl.call(this, id);
-  return this.shopify.request(url, 'DELETE');
+  if (this.shopify.options.presentmentPrices) {
+    url = assign(url, this.shopify.presentmentHeader);
+  }
+
+  return this.shopify.request(url, 'PUT', this.key, params);
 };
 
 /**
@@ -87,7 +88,7 @@ ProductListing.prototype.delete = function(id) {
  */
 ProductListing.prototype.productIds = function productIds(params) {
   const key = 'product_ids';
-  const url = base.buildUrl.call(this, key, params);
+  const url = this.buildUrl(key, params);
   return this.shopify.request(url, 'GET', key);
 };
 

--- a/resources/product-listing.js
+++ b/resources/product-listing.js
@@ -19,7 +19,38 @@ function ProductListing(shopify) {
   this.key = 'product_listing';
 }
 
-assign(ProductListing.prototype, omit(base, ['create', 'update']));
+assign(ProductListing.prototype, omit(base, ['create', 'update', 'buildUrl', 'productIds', 'count', 'delete']));
+
+/**
+ * Builds the request URL.
+ *
+ * @param {Number|String} [id] Record ID
+ * @param {Object} [query] Query parameters
+ * @return {Object} URL object
+ * @private
+ */
+ProductListing.prototype.buildUrl = function(id, query) {
+  const baseUrl = base.buildUrl.call(this, id, query);
+
+  if (this.shopify.options.presentmentPrices) {
+    baseUrl.headers = { ['X-Shopify-Api-Features']: 'include-presentment-prices' };
+  }
+
+  return baseUrl;
+};
+
+/**
+ * Counts the number of records.
+ *
+ * @param {Object} [params] Query parameters
+ * @return {Promise} Promise that resolves with the result
+ * @public
+ */
+ProductListing.prototype.count = function(params) {
+  const key = 'count';
+  const url = base.buildUrl.call(this, key, params);
+  return this.shopify.request(url, 'GET', key);
+};
 
 /**
  * Creates a product listing.
@@ -36,6 +67,18 @@ ProductListing.prototype.create = function create(productId, params) {
 };
 
 /**
+ * Deletes a record.
+ *
+ * @param {Number} id Record ID
+ * @return {Promise} Promise that resolves with the result
+ * @public
+ */
+ProductListing.prototype.delete = function(id) {
+  const url = base.buildUrl.call(this, id);
+  return this.shopify.request(url, 'DELETE');
+};
+
+/**
  * Retrieves product IDs that are published to a particular application.
  *
  * @param {Object} [params] Query parameters
@@ -44,7 +87,7 @@ ProductListing.prototype.create = function create(productId, params) {
  */
 ProductListing.prototype.productIds = function productIds(params) {
   const key = 'product_ids';
-  const url = this.buildUrl(key, params);
+  const url = base.buildUrl.call(this, key, params);
   return this.shopify.request(url, 'GET', key);
 };
 

--- a/resources/product-listing.js
+++ b/resources/product-listing.js
@@ -22,9 +22,9 @@ function ProductListing(shopify) {
 assign(ProductListing.prototype, pick(base, ['count', 'buildUrl', 'delete']));
 
 /**
- * Gets a single record by its ID.
+ * Gets a single product by its ID.
  *
- * @param {Number} id Record ID
+ * @param {Number} id Product ID
  * @param {Object} [params] Query parameters
  * @return {Promise} Promise that resolves with the result
  * @public
@@ -33,16 +33,14 @@ ProductListing.prototype.get = function(id, params) {
   const url = this.buildUrl(id, params);
 
   if (this.shopify.options.presentmentPrices) {
-    url.headers = {
-      ['X-Shopify-Api-Features']: 'include-presentment-prices'
-    };
+    url.headers['X-Shopify-Api-Features'] = 'include-presentment-prices';
   }
 
   return this.shopify.request(url, 'GET', this.key);
 };
 
 /**
- * Gets a list of records.
+ * Gets a list of products.
  *
  * @param {Object} params Query parameters
  * @return {Promise} Promise that resolves with the result
@@ -52,9 +50,7 @@ ProductListing.prototype.list = function(params) {
   const url = this.buildUrl(undefined, params);
 
   if (this.shopify.options.presentmentPrices) {
-    url.headers = {
-      ['X-Shopify-Api-Features']: 'include-presentment-prices'
-    };
+    url.headers['X-Shopify-Api-Features'] = 'include-presentment-prices';
   }
 
   return this.shopify.request(url, 'GET', this.name);
@@ -70,10 +66,10 @@ ProductListing.prototype.list = function(params) {
  */
 ProductListing.prototype.create = function create(productId, params) {
   params || (params = { product_id: productId });
-  let url = this.buildUrl(productId);
+  const url = this.buildUrl(productId);
 
   if (this.shopify.options.presentmentPrices) {
-    url = assign(url, this.shopify.presentmentHeader);
+    url.headers['X-Shopify-Api-Features'] = 'include-presentment-prices';
   }
 
   return this.shopify.request(url, 'PUT', this.key, params);

--- a/resources/product-variant.js
+++ b/resources/product-variant.js
@@ -21,10 +21,11 @@ function ProductVariant(shopify) {
   this.key = 'variant';
 }
 
-assign(
-  ProductVariant.prototype, pick(baseChild,
-    ['buildUrl', 'count', 'delete'])
-);
+assign(ProductVariant.prototype, pick(baseChild, [
+  'buildUrl',
+  'count',
+  'delete'
+]));
 
 /**
  * Gets a single product variant by its ID.
@@ -35,46 +36,46 @@ assign(
  * @public
  */
 ProductVariant.prototype.get = function get(id, params) {
-  let url = base.buildUrl.call(this, id, params);
+  const url = base.buildUrl.call(this, id, params);
 
   if (this.shopify.options.presentmentPrices) {
-    url = assign(url, this.shopify.presentmentHeader);
+    url.headers['X-Shopify-Api-Features'] = 'include-presentment-prices';
   }
 
   return this.shopify.request(url, 'GET', this.key);
 };
 
 /**
- * Creates a new record.
+ * Creates a new product variant.
  *
- * @param {Number} parentId Parent record ID
- * @param {Object} params Record properties
+ * @param {Number} productId Product ID
+ * @param {Object} params Product variant properties
  * @return {Promise} Promise that resolves with the result
  * @public
  */
-ProductVariant.prototype.create = function(parentId, params) {
-  let url = this.buildUrl(parentId);
+ProductVariant.prototype.create = function(productId, params) {
+  const url = this.buildUrl(productId);
 
   if (this.shopify.options.presentmentPrices) {
-    url = assign(url, this.shopify.presentmentHeader);
+    url.headers['X-Shopify-Api-Features'] = 'include-presentment-prices';
   }
 
   return this.shopify.request(url, 'POST', this.key, params);
 };
 
 /**
- * Get a list of records.
+ * Get a list of product variants.
  *
- * @param {Number} parentId Parent record ID
+ * @param {Number} productId Product ID
  * @param {Object} [params] Query parameters
  * @return {Promise} Promise that resolves with the result
  * @public
  */
-ProductVariant.prototype.list = function(parentId, params) {
-  let url = this.buildUrl(parentId, undefined, params);
+ProductVariant.prototype.list = function(productId, params) {
+  const url = this.buildUrl(productId, undefined, params);
 
   if (this.shopify.options.presentmentPrices) {
-    url = assign(url, this.shopify.presentmentHeader);
+    url.headers['X-Shopify-Api-Features'] = 'include-presentment-prices';
   }
 
   return this.shopify.request(url, 'GET', this.name);
@@ -89,10 +90,10 @@ ProductVariant.prototype.list = function(parentId, params) {
  * @public
  */
 ProductVariant.prototype.update = function update(id, params) {
-  let url = base.buildUrl.call(this, id);
+  const url = base.buildUrl.call(this, id);
 
   if (this.shopify.options.presentmentPrices) {
-    url = assign(url, this.shopify.presentmentHeader);
+    url.headers['X-Shopify-Api-Features'] = 'include-presentment-prices';
   }
 
   return this.shopify.request(url, 'PUT', this.key, params);

--- a/resources/product-variant.js
+++ b/resources/product-variant.js
@@ -21,7 +21,40 @@ function ProductVariant(shopify) {
   this.key = 'variant';
 }
 
-assign(ProductVariant.prototype, omit(baseChild, ['get', 'update']));
+assign(ProductVariant.prototype, omit(baseChild, ['get', 'update', 'buildUrl', 'count', 'delete']));
+
+/**
+ * Builds the request URL.
+ *
+ * @param {Number} parentId Parent record ID
+ * @param {Number|String} [id] Record ID
+ * @param {Object} [query] Query parameters
+ * @return {Object} URL object
+ * @private
+ */
+ProductVariant.prototype.buildUrl = function(parentId, id, query) {
+  const baseUrl = baseChild.buildUrl.call(this, parentId, id, query);
+
+  if (this.shopify.options.presentmentPrices) {
+    baseUrl.headers = { ['X-Shopify-Api-Features']: 'include-presentment-prices' };
+  }
+
+  return baseUrl;
+};
+
+/**
+ * Counts the number of records.
+ *
+ * @param {Number} parentId Parent record ID
+ * @param {Object} [params] Query parameters
+ * @return {Promise} Promise that resolves with the result
+ * @public
+ */
+ProductVariant.prototype.count = function(parentId, params) {
+  const key = 'count';
+  const url = baseChild.buildUrl.call(this, parentId, key, params);
+  return this.shopify.request(url, 'GET', key);
+};
 
 /**
  * Gets a single product variant by its ID.
@@ -33,6 +66,11 @@ assign(ProductVariant.prototype, omit(baseChild, ['get', 'update']));
  */
 ProductVariant.prototype.get = function get(id, params) {
   const url = base.buildUrl.call(this, id, params);
+
+  if (this.shopify.options.presentmentPrices) {
+    url.headers = { ['X-Shopify-Api-Features']: 'include-presentment-prices' };
+  }
+
   return this.shopify.request(url, 'GET', this.key);
 };
 
@@ -47,6 +85,20 @@ ProductVariant.prototype.get = function get(id, params) {
 ProductVariant.prototype.update = function update(id, params) {
   const url = base.buildUrl.call(this, id);
   return this.shopify.request(url, 'PUT', this.key, params);
+};
+
+/**
+ * Deletes a record.
+ *
+ * @param {Number} parentId Parent record ID
+ * @param {Number} id Record ID
+ * @param {Object} [params] Query parameters
+ * @return {Promise} Promise that resolves with the result
+ * @public
+ */
+ProductVariant.prototype.delete = function(parentId, id, params) {
+  const url = baseChild.buildUrl.call(this, parentId, id, params);
+  return this.shopify.request(url, 'DELETE');
 };
 
 module.exports = ProductVariant;

--- a/resources/product.js
+++ b/resources/product.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assign = require('lodash/assign');
+const omit = require('lodash/omit');
 
 const base = require('../mixins/base');
 
@@ -18,6 +19,49 @@ function Product(shopify) {
   this.key = 'product';
 }
 
-assign(Product.prototype, base);
+assign(Product.prototype, omit(base, ['buildUrl', 'count', 'delete']));
+
+/**
+ * Builds the request URL.
+ *
+ * @param {Number|String} [id] Record ID
+ * @param {Object} [query] Query parameters
+ * @return {Object} URL object
+ * @private
+ */
+Product.prototype.buildUrl = function(id, query) {
+  const baseUrl = base.buildUrl.call(this, id, query);
+
+  if (this.shopify.options.presentmentPrices) {
+    baseUrl.headers = { ['X-Shopify-Api-Features']: 'include-presentment-prices' };
+  }
+
+  return baseUrl;
+};
+
+/**
+ * Counts the number of records.
+ *
+ * @param {Object} [params] Query parameters
+ * @return {Promise} Promise that resolves with the result
+ * @public
+ */
+Product.prototype.count = function(params) {
+  const key = 'count';
+  const url = base.buildUrl.call(this, key, params);
+  return this.shopify.request(url, 'GET', key);
+};
+
+/**
+ * Deletes a record.
+ *
+ * @param {Number} id Record ID
+ * @return {Promise} Promise that resolves with the result
+ * @public
+ */
+Product.prototype.delete = function(id) {
+  const url = base.buildUrl.call(this, id);
+  return this.shopify.request(url, 'DELETE');
+};
 
 module.exports = Product;

--- a/resources/product.js
+++ b/resources/product.js
@@ -22,70 +22,70 @@ function Product(shopify) {
 assign(Product.prototype, pick(base, ['buildUrl', 'delete', 'count']));
 
 /**
- * Gets a single record by its ID.
+ * Gets a single product by its ID.
  *
- * @param {Number} id Record ID
+ * @param {Number} id Product ID
  * @param {Object} [params] Query parameters
  * @return {Promise} Promise that resolves with the result
  * @public
  */
 Product.prototype.get = function(id, params) {
-  let url = this.buildUrl(id, params);
+  const url = this.buildUrl(id, params);
 
   if (this.shopify.options.presentmentPrices) {
-    url = assign(url, this.shopify.presentmentHeader);
+    url.headers['X-Shopify-Api-Features'] = 'include-presentment-prices';
   }
 
   return this.shopify.request(url, 'GET', this.key);
 };
 
 /**
- * Creates a new record.
+ * Creates a new product.
  *
- * @param {Object} params Record properties
+ * @param {Object} params Product properties
  * @return {Promise} Promise that resolves with the result
  * @public
  */
 Product.prototype.create = function(params) {
-  let url = this.buildUrl();
+  const url = this.buildUrl();
 
   if (this.shopify.options.presentmentPrices) {
-    url = assign(url, this.shopify.presentmentHeader);
+    url.headers['X-Shopify-Api-Features'] = 'include-presentment-prices';
   }
 
   return this.shopify.request(url, 'POST', this.key, params);
 };
 
 /**
- * Gets a list of records.
+ * Gets a list of products.
  *
  * @param {Object} params Query parameters
  * @return {Promise} Promise that resolves with the result
  * @public
  */
 Product.prototype.list = function(params) {
-  let url = this.buildUrl(undefined, params);
+  const url = this.buildUrl(undefined, params);
 
   if (this.shopify.options.presentmentPrices) {
-    url = assign(url, this.shopify.presentmentHeader);
+    url.headers['X-Shopify-Api-Features'] = 'include-presentment-prices';
   }
 
   return this.shopify.request(url, 'GET', this.name);
 };
 
 /**
- * Updates a record.
+ * Updates a product.
  *
- * @param {Number} id Record ID
- * @param {Object} params Record properties
+ * @param {Number} id Products ID
+ * @param {Object} params Products properties
  * @return {Promise} Promise that resolves with the result
  * @public
  */
 Product.prototype.update = function(id, params) {
-  let url = this.buildUrl(id);
+  const url = this.buildUrl(id);
 
   if (this.shopify.options.presentmentPrices) {
-    url = assign(url, this.shopify.presentmentHeader);
+    url.headers['X-Shopify-Api-Features'] = 'include-presentment-prices';
   }
 
   return this.shopify.request(url, 'PUT', this.key, params);

--- a/test/common.js
+++ b/test/common.js
@@ -11,7 +11,7 @@ const apiKey = 'bc731e500840231da5b43bb3f388d2f0';
 const apiVersion = '2019-04';
 const shopName ='johns-apparel';
 
-const shopify = new Shopify({ shopName, accessToken });
+const shopify = new Shopify({ shopName, accessToken, presentmentPrices:true });
 
 const scope = nock(`https://${shopName}.myshopify.com`, {
   reqheaders: {

--- a/test/common.js
+++ b/test/common.js
@@ -12,7 +12,11 @@ const apiVersion = '2019-04';
 const shopName ='johns-apparel';
 
 const shopify = new Shopify({ shopName, accessToken });
-const shopifyWithPresentmentOption = new Shopify({ shopName, accessToken, presentmentPrices: true });
+const shopifyWithPresentmentOption = new Shopify({
+  accessToken,
+  presentmentPrices: true,
+  shopName
+});
 
 const scope = nock(`https://${shopName}.myshopify.com`, {
   reqheaders: {
@@ -27,19 +31,19 @@ const presentmentApiScope = nock(`https://${shopName}.myshopify.com`, {
   reqheaders: {
     'User-Agent': `${pkg.name}/${pkg.version}`,
     'X-Shopify-Access-Token': accessToken,
+    'X-Shopify-Api-Features': 'include-presentment-prices',
     'Accept': 'application/json'
   }
-})
-  .matchHeader('X-Shopify-Api-Features', 'include-presentment-prices');
+});
 
 module.exports = {
   accessToken,
-  password,
-  shopName,
-  shopify,
   apiKey,
   apiVersion,
-  scope,
+  password,
   presentmentApiScope,
-  shopifyWithPresentmentOption
+  scope,
+  shopify,
+  shopifyWithPresentmentOption,
+  shopName
 };

--- a/test/common.js
+++ b/test/common.js
@@ -11,7 +11,8 @@ const apiKey = 'bc731e500840231da5b43bb3f388d2f0';
 const apiVersion = '2019-04';
 const shopName ='johns-apparel';
 
-const shopify = new Shopify({ shopName, accessToken, presentmentPrices:true });
+const shopify = new Shopify({ shopName, accessToken });
+const shopifyWithPresentmentOption = new Shopify({ shopName, accessToken, presentmentPrices: true });
 
 const scope = nock(`https://${shopName}.myshopify.com`, {
   reqheaders: {
@@ -22,7 +23,7 @@ const scope = nock(`https://${shopName}.myshopify.com`, {
   badheaders: ['X-Shopify-Api-Features']
 });
 
-const productApiScope = nock(`https://${shopName}.myshopify.com`, {
+const presentmentApiScope = nock(`https://${shopName}.myshopify.com`, {
   reqheaders: {
     'User-Agent': `${pkg.name}/${pkg.version}`,
     'X-Shopify-Access-Token': accessToken,
@@ -39,5 +40,6 @@ module.exports = {
   apiKey,
   apiVersion,
   scope,
-  productApiScope
+  presentmentApiScope,
+  shopifyWithPresentmentOption
 };

--- a/test/common.js
+++ b/test/common.js
@@ -18,8 +18,18 @@ const scope = nock(`https://${shopName}.myshopify.com`, {
     'User-Agent': `${pkg.name}/${pkg.version}`,
     'X-Shopify-Access-Token': accessToken,
     'Accept': 'application/json'
-  }
+  },
+  badheaders: ['X-Shopify-Api-Features']
 });
+
+const productApiScope = nock(`https://${shopName}.myshopify.com`, {
+  reqheaders: {
+    'User-Agent': `${pkg.name}/${pkg.version}`,
+    'X-Shopify-Access-Token': accessToken,
+    'Accept': 'application/json'
+  }
+})
+  .matchHeader('X-Shopify-Api-Features', 'include-presentment-prices');
 
 module.exports = {
   accessToken,
@@ -28,5 +38,6 @@ module.exports = {
   shopify,
   apiKey,
   apiVersion,
-  scope
+  scope,
+  productApiScope
 };

--- a/test/product-listing.test.js
+++ b/test/product-listing.test.js
@@ -11,9 +11,12 @@ describe('Shopify#productListing', () => {
   const standardScope = common.scope;
   const presentmentApiScope = common.presentmentApiScope;
 
-  afterEach(() => expect(standardScope.isDone()).to.be.true);
+  afterEach(() => {
+    expect(presentmentApiScope.isDone()).to.be.true;
+    expect(standardScope.isDone()).to.be.true;
+  });
 
-  it('gets product listings published to an application (1/2)', () => {
+  it('gets product listings published to an application (1/4)', () => {
     const output = fixtures.res.list;
 
     standardScope
@@ -24,7 +27,7 @@ describe('Shopify#productListing', () => {
       .then(data => expect(data).to.deep.equal(output.product_listings));
   });
 
-  it('gets product listings published to an application (2/2)', () => {
+  it('gets product listings published to an application (2/4)', () => {
     const output = fixtures.res.list;
 
     standardScope
@@ -35,7 +38,7 @@ describe('Shopify#productListing', () => {
       .then(data => expect(data).to.deep.equal(output.product_listings));
   });
 
-  it('gets product listings published to an application (1/2) with presentment option', () => {
+  it('gets product listings published to an application (3/4)', () => {
     const output = fixtures.res.list;
 
     presentmentApiScope
@@ -46,7 +49,7 @@ describe('Shopify#productListing', () => {
       .then(data => expect(data).to.deep.equal(output.product_listings));
   });
 
-  it('gets product listings published to an application (2/2) with presentment option', () => {
+  it('gets product listings published to an application (4/4)', () => {
     const output = fixtures.res.list;
 
     presentmentApiScope
@@ -110,7 +113,7 @@ describe('Shopify#productListing', () => {
       .then(data => expect(data).to.deep.equal(output.product_listing));
   });
 
-  it('creates a product listing (1/2)', () => {
+  it('creates a product listing (1/4)', () => {
     const input = fixtures.req.create;
     const output = fixtures.res.create;
 
@@ -122,7 +125,7 @@ describe('Shopify#productListing', () => {
       .then(data => expect(data).to.deep.equal(output.product_listing));
   });
 
-  it('creates a product listing (2/2)', () => {
+  it('creates a product listing (2/4)', () => {
     const input = fixtures.req.create;
     const output = fixtures.res.create;
 
@@ -134,7 +137,7 @@ describe('Shopify#productListing', () => {
       .then(data => expect(data).to.deep.equal(output.product_listing));
   });
 
-  it('creates a product listing (1/2) with presentment option', () => {
+  it('creates a product listing (3/4)', () => {
     const input = fixtures.req.create;
     const output = fixtures.res.create;
 
@@ -146,7 +149,7 @@ describe('Shopify#productListing', () => {
       .then(data => expect(data).to.deep.equal(output.product_listing));
   });
 
-  it('creates a product listing (2/2) with presentment option', () => {
+  it('creates a product listing (4/4)', () => {
     const input = fixtures.req.create;
     const output = fixtures.res.create;
 
@@ -154,7 +157,8 @@ describe('Shopify#productListing', () => {
       .put('/admin/product_listings/921728736.json', input)
       .reply(200, output);
 
-    return shopifyWithPresenmentOption.productListing.create(921728736, input.product_listing)
+    return shopifyWithPresenmentOption.productListing
+      .create(921728736, input.product_listing)
       .then(data => expect(data).to.deep.equal(output.product_listing));
   });
 

--- a/test/product-listing.test.js
+++ b/test/product-listing.test.js
@@ -7,15 +7,16 @@ describe('Shopify#productListing', () => {
   const common = require('./common');
 
   const shopify = common.shopify;
+  const shopifyWithPresenmentOption = common.shopifyWithPresentmentOption;
   const standardScope = common.scope;
-  const productApiScope = common.productApiScope;
+  const presentmentApiScope = common.presentmentApiScope;
 
   afterEach(() => expect(standardScope.isDone()).to.be.true);
 
   it('gets product listings published to an application (1/2)', () => {
     const output = fixtures.res.list;
 
-    productApiScope
+    standardScope
       .get('/admin/product_listings.json')
       .reply(200, output);
 
@@ -26,11 +27,33 @@ describe('Shopify#productListing', () => {
   it('gets product listings published to an application (2/2)', () => {
     const output = fixtures.res.list;
 
-    productApiScope
+    standardScope
       .get('/admin/product_listings.json?page=1')
       .reply(200, output);
 
     return shopify.productListing.list({ page: 1 })
+      .then(data => expect(data).to.deep.equal(output.product_listings));
+  });
+
+  it('gets product listings published to an application (1/2) with presentment option', () => {
+    const output = fixtures.res.list;
+
+    presentmentApiScope
+      .get('/admin/product_listings.json')
+      .reply(200, output);
+
+    return shopifyWithPresenmentOption.productListing.list()
+      .then(data => expect(data).to.deep.equal(output.product_listings));
+  });
+
+  it('gets product listings published to an application (2/2) with presentment option', () => {
+    const output = fixtures.res.list;
+
+    presentmentApiScope
+      .get('/admin/product_listings.json?page=1')
+      .reply(200, output);
+
+    return shopifyWithPresenmentOption.productListing.list({ page: 1 })
       .then(data => expect(data).to.deep.equal(output.product_listings));
   });
 
@@ -68,7 +91,7 @@ describe('Shopify#productListing', () => {
   it('gets a specific product listing', () => {
     const output = fixtures.res.get;
 
-    productApiScope
+    standardScope
       .get('/admin/product_listings/921728736.json')
       .reply(200, output);
 
@@ -76,11 +99,22 @@ describe('Shopify#productListing', () => {
       .then(data => expect(data).to.deep.equal(output.product_listing));
   });
 
+  it('gets a specific product listing with presentment option', () => {
+    const output = fixtures.res.get;
+
+    presentmentApiScope
+      .get('/admin/product_listings/921728736.json')
+      .reply(200, output);
+
+    return shopifyWithPresenmentOption.productListing.get(921728736)
+      .then(data => expect(data).to.deep.equal(output.product_listing));
+  });
+
   it('creates a product listing (1/2)', () => {
     const input = fixtures.req.create;
     const output = fixtures.res.create;
 
-    productApiScope
+    standardScope
       .put('/admin/product_listings/921728736.json', input)
       .reply(200, output);
 
@@ -92,11 +126,35 @@ describe('Shopify#productListing', () => {
     const input = fixtures.req.create;
     const output = fixtures.res.create;
 
-    productApiScope
+    standardScope
       .put('/admin/product_listings/921728736.json', input)
       .reply(200, output);
 
     return shopify.productListing.create(921728736, input.product_listing)
+      .then(data => expect(data).to.deep.equal(output.product_listing));
+  });
+
+  it('creates a product listing (1/2) with presentment option', () => {
+    const input = fixtures.req.create;
+    const output = fixtures.res.create;
+
+    presentmentApiScope
+      .put('/admin/product_listings/921728736.json', input)
+      .reply(200, output);
+
+    return shopifyWithPresenmentOption.productListing.create(921728736)
+      .then(data => expect(data).to.deep.equal(output.product_listing));
+  });
+
+  it('creates a product listing (2/2) with presentment option', () => {
+    const input = fixtures.req.create;
+    const output = fixtures.res.create;
+
+    presentmentApiScope
+      .put('/admin/product_listings/921728736.json', input)
+      .reply(200, output);
+
+    return shopifyWithPresenmentOption.productListing.create(921728736, input.product_listing)
       .then(data => expect(data).to.deep.equal(output.product_listing));
   });
 

--- a/test/product-listing.test.js
+++ b/test/product-listing.test.js
@@ -80,7 +80,7 @@ describe('Shopify#productListing', () => {
     const input = fixtures.req.create;
     const output = fixtures.res.create;
 
-    standardScope
+    productApiScope
       .put('/admin/product_listings/921728736.json', input)
       .reply(200, output);
 
@@ -92,7 +92,7 @@ describe('Shopify#productListing', () => {
     const input = fixtures.req.create;
     const output = fixtures.res.create;
 
-    standardScope
+    productApiScope
       .put('/admin/product_listings/921728736.json', input)
       .reply(200, output);
 

--- a/test/product-listing.test.js
+++ b/test/product-listing.test.js
@@ -7,14 +7,15 @@ describe('Shopify#productListing', () => {
   const common = require('./common');
 
   const shopify = common.shopify;
-  const scope = common.scope;
+  const standardScope = common.scope;
+  const productApiScope = common.productApiScope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(standardScope.isDone()).to.be.true);
 
   it('gets product listings published to an application (1/2)', () => {
     const output = fixtures.res.list;
 
-    scope
+    productApiScope
       .get('/admin/product_listings.json')
       .reply(200, output);
 
@@ -25,7 +26,7 @@ describe('Shopify#productListing', () => {
   it('gets product listings published to an application (2/2)', () => {
     const output = fixtures.res.list;
 
-    scope
+    productApiScope
       .get('/admin/product_listings.json?page=1')
       .reply(200, output);
 
@@ -36,7 +37,7 @@ describe('Shopify#productListing', () => {
   it('gets product IDs published to an application (1/2)', () => {
     const output = fixtures.res.productIds;
 
-    scope
+    standardScope
       .get('/admin/product_listings/product_ids.json')
       .reply(200, output);
 
@@ -47,7 +48,7 @@ describe('Shopify#productListing', () => {
   it('gets product IDs published to an application (2/2)', () => {
     const output = fixtures.res.productIds;
 
-    scope
+    standardScope
       .get('/admin/product_listings/product_ids.json?page=1')
       .reply(200, output);
 
@@ -56,7 +57,7 @@ describe('Shopify#productListing', () => {
   });
 
   it('gets a count of products published to an application', () => {
-    scope
+    standardScope
       .get('/admin/product_listings/count.json')
       .reply(200, { count: 2 });
 
@@ -67,7 +68,7 @@ describe('Shopify#productListing', () => {
   it('gets a specific product listing', () => {
     const output = fixtures.res.get;
 
-    scope
+    productApiScope
       .get('/admin/product_listings/921728736.json')
       .reply(200, output);
 
@@ -79,7 +80,7 @@ describe('Shopify#productListing', () => {
     const input = fixtures.req.create;
     const output = fixtures.res.create;
 
-    scope
+    standardScope
       .put('/admin/product_listings/921728736.json', input)
       .reply(200, output);
 
@@ -91,7 +92,7 @@ describe('Shopify#productListing', () => {
     const input = fixtures.req.create;
     const output = fixtures.res.create;
 
-    scope
+    standardScope
       .put('/admin/product_listings/921728736.json', input)
       .reply(200, output);
 
@@ -100,7 +101,7 @@ describe('Shopify#productListing', () => {
   });
 
   it('deletes a product listing', () => {
-    scope
+    standardScope
       .delete('/admin/product_listings/921728736.json')
       .reply(200);
 

--- a/test/product-variant.test.js
+++ b/test/product-variant.test.js
@@ -7,15 +7,16 @@ describe('Shopify#productVariant', () => {
   const common = require('./common');
 
   const shopify = common.shopify;
+  const shopifyWithPresenmentOption = common.shopifyWithPresentmentOption;
   const standardScope = common.scope;
-  const productApiScope = common.productApiScope;
+  const presentmentApiScope = common.presentmentApiScope;
 
   afterEach(() => expect(standardScope.isDone()).to.be.true);
 
   it('gets a list of all product variants for a product (1/2)', () => {
     const output = fixtures.res.list;
 
-    productApiScope
+    standardScope
       .get('/admin/products/632910392/variants.json')
       .reply(200, output);
 
@@ -26,11 +27,33 @@ describe('Shopify#productVariant', () => {
   it('gets a list of all product variants for a product (2/2)', () => {
     const output = fixtures.res.list;
 
-    productApiScope
+    standardScope
       .get('/admin/products/632910392/variants.json?since_id=39072855')
       .reply(200, output);
 
     return shopify.productVariant.list(632910392, { since_id: 39072855 })
+      .then(data => expect(data).to.deep.equal(output.variants));
+  });
+
+  it('gets a list of all product variants for a product (1/2) with presentment option', () => {
+    const output = fixtures.res.list;
+
+    presentmentApiScope
+      .get('/admin/products/632910392/variants.json')
+      .reply(200, output);
+
+    return shopifyWithPresenmentOption.productVariant.list(632910392)
+      .then(data => expect(data).to.deep.equal(output.variants));
+  });
+
+  it('gets a list of all product variants for a product (2/2) with presentment option', () => {
+    const output = fixtures.res.list;
+
+    presentmentApiScope
+      .get('/admin/products/632910392/variants.json?since_id=39072855')
+      .reply(200, output);
+
+    return shopifyWithPresenmentOption.productVariant.list(632910392, { since_id: 39072855 })
       .then(data => expect(data).to.deep.equal(output.variants));
   });
 
@@ -46,7 +69,7 @@ describe('Shopify#productVariant', () => {
   it('gets a single product variant by its ID (1/2)', () => {
     const output = fixtures.res.get;
 
-    productApiScope
+    standardScope
       .get('/admin/variants/808950810.json')
       .reply(200, output);
 
@@ -57,7 +80,7 @@ describe('Shopify#productVariant', () => {
   it('gets a single product variant by its ID (2/2)', () => {
     const output = fixtures.res.get;
 
-    productApiScope
+    standardScope
       .get('/admin/variants/808950810.json?foo=bar')
       .reply(200, output);
 
@@ -65,15 +88,49 @@ describe('Shopify#productVariant', () => {
       .then(data => expect(data).to.deep.equal(output.variant));
   });
 
+  it('gets a single product variant by its ID (1/2) with presentment option', () => {
+    const output = fixtures.res.get;
+
+    presentmentApiScope
+      .get('/admin/variants/808950810.json')
+      .reply(200, output);
+
+    return shopifyWithPresenmentOption.productVariant.get(808950810)
+      .then(data => expect(data).to.deep.equal(output.variant));
+  });
+
+  it('gets a single product variant by its ID (2/2) with presentment option', () => {
+    const output = fixtures.res.get;
+
+    presentmentApiScope
+      .get('/admin/variants/808950810.json?foo=bar')
+      .reply(200, output);
+
+    return shopifyWithPresenmentOption.productVariant.get(808950810, { foo: 'bar' })
+      .then(data => expect(data).to.deep.equal(output.variant));
+  });
+
   it('creates a new product variant', () => {
     const input = fixtures.req.create;
     const output = fixtures.res.create;
 
-    productApiScope
+    standardScope
       .post('/admin/products/632910392/variants.json', input)
       .reply(201, output);
 
     return shopify.productVariant.create(632910392, input.variant)
+      .then(data => expect(data).to.deep.equal(output.variant));
+  });
+
+  it('creates a new product variant with presentment option', () => {
+    const input = fixtures.req.create;
+    const output = fixtures.res.create;
+
+    presentmentApiScope
+      .post('/admin/products/632910392/variants.json', input)
+      .reply(201, output);
+
+    return shopifyWithPresenmentOption.productVariant.create(632910392, input.variant)
       .then(data => expect(data).to.deep.equal(output.variant));
   });
 
@@ -86,6 +143,18 @@ describe('Shopify#productVariant', () => {
       .reply(200, output);
 
     return shopify.productVariant.update(808950810, input.variant)
+      .then(data => expect(data).to.deep.equal(output.variant));
+  });
+
+  it('updates a product variant with presentment option', () => {
+    const input = fixtures.req.update;
+    const output = fixtures.res.update;
+
+    presentmentApiScope
+      .put('/admin/variants/808950810.json', input)
+      .reply(200, output);
+
+    return shopifyWithPresenmentOption.productVariant.update(808950810, input.variant)
       .then(data => expect(data).to.deep.equal(output.variant));
   });
 

--- a/test/product-variant.test.js
+++ b/test/product-variant.test.js
@@ -69,7 +69,7 @@ describe('Shopify#productVariant', () => {
     const input = fixtures.req.create;
     const output = fixtures.res.create;
 
-    standardScope
+    productApiScope
       .post('/admin/products/632910392/variants.json', input)
       .reply(201, output);
 

--- a/test/product-variant.test.js
+++ b/test/product-variant.test.js
@@ -11,9 +11,12 @@ describe('Shopify#productVariant', () => {
   const standardScope = common.scope;
   const presentmentApiScope = common.presentmentApiScope;
 
-  afterEach(() => expect(standardScope.isDone()).to.be.true);
+  afterEach(() => {
+    expect(presentmentApiScope.isDone()).to.be.true;
+    expect(standardScope.isDone()).to.be.true;
+  });
 
-  it('gets a list of all product variants for a product (1/2)', () => {
+  it('gets a list of all product variants for a product (1/4)', () => {
     const output = fixtures.res.list;
 
     standardScope
@@ -24,7 +27,7 @@ describe('Shopify#productVariant', () => {
       .then(data => expect(data).to.deep.equal(output.variants));
   });
 
-  it('gets a list of all product variants for a product (2/2)', () => {
+  it('gets a list of all product variants for a product (2/4)', () => {
     const output = fixtures.res.list;
 
     standardScope
@@ -35,7 +38,7 @@ describe('Shopify#productVariant', () => {
       .then(data => expect(data).to.deep.equal(output.variants));
   });
 
-  it('gets a list of all product variants for a product (1/2) with presentment option', () => {
+  it('gets a list of all product variants for a product (3/4)', () => {
     const output = fixtures.res.list;
 
     presentmentApiScope
@@ -46,14 +49,15 @@ describe('Shopify#productVariant', () => {
       .then(data => expect(data).to.deep.equal(output.variants));
   });
 
-  it('gets a list of all product variants for a product (2/2) with presentment option', () => {
+  it('gets a list of all product variants for a product (4/4)', () => {
     const output = fixtures.res.list;
 
     presentmentApiScope
       .get('/admin/products/632910392/variants.json?since_id=39072855')
       .reply(200, output);
 
-    return shopifyWithPresenmentOption.productVariant.list(632910392, { since_id: 39072855 })
+    return shopifyWithPresenmentOption.productVariant
+      .list(632910392, { since_id: 39072855 })
       .then(data => expect(data).to.deep.equal(output.variants));
   });
 
@@ -66,7 +70,7 @@ describe('Shopify#productVariant', () => {
       .then(data => expect(data).to.equal(4));
   });
 
-  it('gets a single product variant by its ID (1/2)', () => {
+  it('gets a single product variant by its ID (1/4)', () => {
     const output = fixtures.res.get;
 
     standardScope
@@ -77,7 +81,7 @@ describe('Shopify#productVariant', () => {
       .then(data => expect(data).to.deep.equal(output.variant));
   });
 
-  it('gets a single product variant by its ID (2/2)', () => {
+  it('gets a single product variant by its ID (2/4)', () => {
     const output = fixtures.res.get;
 
     standardScope
@@ -88,7 +92,7 @@ describe('Shopify#productVariant', () => {
       .then(data => expect(data).to.deep.equal(output.variant));
   });
 
-  it('gets a single product variant by its ID (1/2) with presentment option', () => {
+  it('gets a single product variant by its ID (3/4)', () => {
     const output = fixtures.res.get;
 
     presentmentApiScope
@@ -99,14 +103,15 @@ describe('Shopify#productVariant', () => {
       .then(data => expect(data).to.deep.equal(output.variant));
   });
 
-  it('gets a single product variant by its ID (2/2) with presentment option', () => {
+  it('gets a single product variant by its ID (4/4)', () => {
     const output = fixtures.res.get;
 
     presentmentApiScope
       .get('/admin/variants/808950810.json?foo=bar')
       .reply(200, output);
 
-    return shopifyWithPresenmentOption.productVariant.get(808950810, { foo: 'bar' })
+    return shopifyWithPresenmentOption.productVariant
+      .get(808950810, { foo: 'bar' })
       .then(data => expect(data).to.deep.equal(output.variant));
   });
 
@@ -130,7 +135,8 @@ describe('Shopify#productVariant', () => {
       .post('/admin/products/632910392/variants.json', input)
       .reply(201, output);
 
-    return shopifyWithPresenmentOption.productVariant.create(632910392, input.variant)
+    return shopifyWithPresenmentOption.productVariant
+      .create(632910392, input.variant)
       .then(data => expect(data).to.deep.equal(output.variant));
   });
 
@@ -154,7 +160,8 @@ describe('Shopify#productVariant', () => {
       .put('/admin/variants/808950810.json', input)
       .reply(200, output);
 
-    return shopifyWithPresenmentOption.productVariant.update(808950810, input.variant)
+    return shopifyWithPresenmentOption.productVariant
+      .update(808950810, input.variant)
       .then(data => expect(data).to.deep.equal(output.variant));
   });
 

--- a/test/product-variant.test.js
+++ b/test/product-variant.test.js
@@ -7,14 +7,15 @@ describe('Shopify#productVariant', () => {
   const common = require('./common');
 
   const shopify = common.shopify;
-  const scope = common.scope;
+  const standardScope = common.scope;
+  const productApiScope = common.productApiScope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(standardScope.isDone()).to.be.true);
 
   it('gets a list of all product variants for a product (1/2)', () => {
     const output = fixtures.res.list;
 
-    scope
+    productApiScope
       .get('/admin/products/632910392/variants.json')
       .reply(200, output);
 
@@ -25,7 +26,7 @@ describe('Shopify#productVariant', () => {
   it('gets a list of all product variants for a product (2/2)', () => {
     const output = fixtures.res.list;
 
-    scope
+    productApiScope
       .get('/admin/products/632910392/variants.json?since_id=39072855')
       .reply(200, output);
 
@@ -34,7 +35,7 @@ describe('Shopify#productVariant', () => {
   });
 
   it('gets a count of all product variants', () => {
-    scope
+    standardScope
       .get('/admin/products/632910392/variants/count.json')
       .reply(200, { count: 4 });
 
@@ -45,7 +46,7 @@ describe('Shopify#productVariant', () => {
   it('gets a single product variant by its ID (1/2)', () => {
     const output = fixtures.res.get;
 
-    scope
+    productApiScope
       .get('/admin/variants/808950810.json')
       .reply(200, output);
 
@@ -56,7 +57,7 @@ describe('Shopify#productVariant', () => {
   it('gets a single product variant by its ID (2/2)', () => {
     const output = fixtures.res.get;
 
-    scope
+    productApiScope
       .get('/admin/variants/808950810.json?foo=bar')
       .reply(200, output);
 
@@ -68,7 +69,7 @@ describe('Shopify#productVariant', () => {
     const input = fixtures.req.create;
     const output = fixtures.res.create;
 
-    scope
+    standardScope
       .post('/admin/products/632910392/variants.json', input)
       .reply(201, output);
 
@@ -80,7 +81,7 @@ describe('Shopify#productVariant', () => {
     const input = fixtures.req.update;
     const output = fixtures.res.update;
 
-    scope
+    standardScope
       .put('/admin/variants/808950810.json', input)
       .reply(200, output);
 
@@ -89,7 +90,7 @@ describe('Shopify#productVariant', () => {
   });
 
   it('deletes a product variant', () => {
-    scope
+    standardScope
       .delete('/admin/products/632910392/variants/808950810.json')
       .reply(200, {});
 

--- a/test/product.test.js
+++ b/test/product.test.js
@@ -16,6 +16,7 @@ describe('Shopify#product', () => {
 
     scope
       .get('/admin/products.json')
+      .matchHeader('X-Shopify-Api-Features', 'include-presentment-prices')
       .reply(200, output);
 
     return shopify.product.list()

--- a/test/product.test.js
+++ b/test/product.test.js
@@ -78,7 +78,7 @@ describe('Shopify#product', () => {
     const input = fixtures.req.create;
     const output = fixtures.res.create;
 
-    standardScope
+    productApiScope
       .post('/admin/products.json', input)
       .reply(201, output);
 
@@ -90,7 +90,7 @@ describe('Shopify#product', () => {
     const input = fixtures.req.update;
     const output = fixtures.res.update;
 
-    standardScope
+    productApiScope
       .put('/admin/products/632910392.json', input)
       .reply(200, output);
 

--- a/test/product.test.js
+++ b/test/product.test.js
@@ -7,16 +7,16 @@ describe('Shopify#product', () => {
   const common = require('./common');
 
   const shopify = common.shopify;
-  const scope = common.scope;
+  const standardScope = common.scope;
+  const productApiScope = common.productApiScope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(standardScope.isDone()).to.be.true);
 
   it('gets a list of all products (1/2)', () => {
     const output = fixtures.res.list;
 
-    scope
+    productApiScope
       .get('/admin/products.json')
-      .matchHeader('X-Shopify-Api-Features', 'include-presentment-prices')
       .reply(200, output);
 
     return shopify.product.list()
@@ -26,7 +26,7 @@ describe('Shopify#product', () => {
   it('gets a list of all products (2/2)', () => {
     const output = fixtures.res.list;
 
-    scope
+    productApiScope
       .get('/admin/products.json?published_status=any')
       .reply(200, output);
 
@@ -35,7 +35,7 @@ describe('Shopify#product', () => {
   });
 
   it('gets a count of all products (1/2)', () => {
-    scope
+    standardScope
       .get('/admin/products/count.json')
       .reply(200, { count: 2 });
 
@@ -44,7 +44,7 @@ describe('Shopify#product', () => {
   });
 
   it('gets a count of all products (2/2)', () => {
-    scope
+    standardScope
       .get('/admin/products/count.json?published_status=any')
       .reply(200, { count: 2 });
 
@@ -55,7 +55,7 @@ describe('Shopify#product', () => {
   it('gets a single product by its ID (1/2)', () => {
     const output = fixtures.res.get;
 
-    scope
+    productApiScope
       .get('/admin/products/632910392.json')
       .reply(200, output);
 
@@ -66,7 +66,7 @@ describe('Shopify#product', () => {
   it('gets a single product by its ID (2/2)', () => {
     const output = fixtures.res.get;
 
-    scope
+    productApiScope
       .get('/admin/products/632910392.json?foo=bar')
       .reply(200, output);
 
@@ -78,7 +78,7 @@ describe('Shopify#product', () => {
     const input = fixtures.req.create;
     const output = fixtures.res.create;
 
-    scope
+    standardScope
       .post('/admin/products.json', input)
       .reply(201, output);
 
@@ -90,7 +90,7 @@ describe('Shopify#product', () => {
     const input = fixtures.req.update;
     const output = fixtures.res.update;
 
-    scope
+    standardScope
       .put('/admin/products/632910392.json', input)
       .reply(200, output);
 
@@ -99,7 +99,7 @@ describe('Shopify#product', () => {
   });
 
   it('deletes a product', () => {
-    scope
+    standardScope
       .delete('/admin/products/632910392.json')
       .reply(200, {});
 

--- a/test/product.test.js
+++ b/test/product.test.js
@@ -11,9 +11,12 @@ describe('Shopify#product', () => {
   const standardScope = common.scope;
   const presentmentApiScope = common.presentmentApiScope;
 
-  afterEach(() => expect(standardScope.isDone()).to.be.true);
+  afterEach(() => {
+    expect(presentmentApiScope.isDone()).to.be.true;
+    expect(standardScope.isDone()).to.be.true;
+  });
 
-  it('gets a list of all products (1/2)', () => {
+  it('gets a list of all products (1/4)', () => {
     const output = fixtures.res.list;
 
     standardScope
@@ -24,7 +27,7 @@ describe('Shopify#product', () => {
       .then(data => expect(data).to.deep.equal(output.products));
   });
 
-  it('gets a list of all products (2/2)', () => {
+  it('gets a list of all products (2/4)', () => {
     const output = fixtures.res.list;
 
     standardScope
@@ -35,7 +38,7 @@ describe('Shopify#product', () => {
       .then(data => expect(data).to.deep.equal(output.products));
   });
 
-  it('gets a list of all products (1/2) with presentment option', () => {
+  it('gets a list of all products (3/4)', () => {
     const output = fixtures.res.list;
 
     presentmentApiScope
@@ -46,7 +49,7 @@ describe('Shopify#product', () => {
       .then(data => expect(data).to.deep.equal(output.products));
   });
 
-  it('gets a list of all products (2/2) with presentment option', () => {
+  it('gets a list of all products (4/4)', () => {
     const output = fixtures.res.list;
 
     presentmentApiScope
@@ -75,7 +78,7 @@ describe('Shopify#product', () => {
       .then(data => expect(data).to.equal(2));
   });
 
-  it('gets a single product by its ID (1/2)', () => {
+  it('gets a single product by its ID (1/4)', () => {
     const output = fixtures.res.get;
 
     standardScope
@@ -86,7 +89,7 @@ describe('Shopify#product', () => {
       .then(data => expect(data).to.deep.equal(output.product));
   });
 
-  it('gets a single product by its ID (2/2)', () => {
+  it('gets a single product by its ID (2/4)', () => {
     const output = fixtures.res.get;
 
     standardScope
@@ -97,7 +100,7 @@ describe('Shopify#product', () => {
       .then(data => expect(data).to.deep.equal(output.product));
   });
 
-  it('gets a single product by its ID (1/2) with presentment option', () => {
+  it('gets a single product by its ID (3/4)', () => {
     const output = fixtures.res.get;
 
     presentmentApiScope
@@ -108,7 +111,7 @@ describe('Shopify#product', () => {
       .then(data => expect(data).to.deep.equal(output.product));
   });
 
-  it('gets a single product by its ID (2/2) with presentment option', () => {
+  it('gets a single product by its ID (4/4)', () => {
     const output = fixtures.res.get;
 
     presentmentApiScope

--- a/test/product.test.js
+++ b/test/product.test.js
@@ -7,15 +7,16 @@ describe('Shopify#product', () => {
   const common = require('./common');
 
   const shopify = common.shopify;
+  const shopifyWithPresenmentOption = common.shopifyWithPresentmentOption;
   const standardScope = common.scope;
-  const productApiScope = common.productApiScope;
+  const presentmentApiScope = common.presentmentApiScope;
 
   afterEach(() => expect(standardScope.isDone()).to.be.true);
 
   it('gets a list of all products (1/2)', () => {
     const output = fixtures.res.list;
 
-    productApiScope
+    standardScope
       .get('/admin/products.json')
       .reply(200, output);
 
@@ -26,11 +27,33 @@ describe('Shopify#product', () => {
   it('gets a list of all products (2/2)', () => {
     const output = fixtures.res.list;
 
-    productApiScope
+    standardScope
       .get('/admin/products.json?published_status=any')
       .reply(200, output);
 
     return shopify.product.list({ published_status: 'any' })
+      .then(data => expect(data).to.deep.equal(output.products));
+  });
+
+  it('gets a list of all products (1/2) with presentment option', () => {
+    const output = fixtures.res.list;
+
+    presentmentApiScope
+      .get('/admin/products.json')
+      .reply(200, output);
+
+    return shopifyWithPresenmentOption.product.list()
+      .then(data => expect(data).to.deep.equal(output.products));
+  });
+
+  it('gets a list of all products (2/2) with presentment option', () => {
+    const output = fixtures.res.list;
+
+    presentmentApiScope
+      .get('/admin/products.json?published_status=any')
+      .reply(200, output);
+
+    return shopifyWithPresenmentOption.product.list({ published_status: 'any' })
       .then(data => expect(data).to.deep.equal(output.products));
   });
 
@@ -55,7 +78,7 @@ describe('Shopify#product', () => {
   it('gets a single product by its ID (1/2)', () => {
     const output = fixtures.res.get;
 
-    productApiScope
+    standardScope
       .get('/admin/products/632910392.json')
       .reply(200, output);
 
@@ -66,7 +89,7 @@ describe('Shopify#product', () => {
   it('gets a single product by its ID (2/2)', () => {
     const output = fixtures.res.get;
 
-    productApiScope
+    standardScope
       .get('/admin/products/632910392.json?foo=bar')
       .reply(200, output);
 
@@ -74,11 +97,33 @@ describe('Shopify#product', () => {
       .then(data => expect(data).to.deep.equal(output.product));
   });
 
+  it('gets a single product by its ID (1/2) with presentment option', () => {
+    const output = fixtures.res.get;
+
+    presentmentApiScope
+      .get('/admin/products/632910392.json')
+      .reply(200, output);
+
+    return shopifyWithPresenmentOption.product.get(632910392)
+      .then(data => expect(data).to.deep.equal(output.product));
+  });
+
+  it('gets a single product by its ID (2/2) with presentment option', () => {
+    const output = fixtures.res.get;
+
+    presentmentApiScope
+      .get('/admin/products/632910392.json?foo=bar')
+      .reply(200, output);
+
+    return shopifyWithPresenmentOption.product.get(632910392, { foo: 'bar' })
+      .then(data => expect(data).to.deep.equal(output.product));
+  });
+
   it('creates a new product', () => {
     const input = fixtures.req.create;
     const output = fixtures.res.create;
 
-    productApiScope
+    standardScope
       .post('/admin/products.json', input)
       .reply(201, output);
 
@@ -86,15 +131,39 @@ describe('Shopify#product', () => {
       .then(data => expect(data).to.deep.equal(output.product));
   });
 
+  it('creates a new product with presentment option', () => {
+    const input = fixtures.req.create;
+    const output = fixtures.res.create;
+
+    presentmentApiScope
+      .post('/admin/products.json', input)
+      .reply(201, output);
+
+    return shopifyWithPresenmentOption.product.create(input.product)
+      .then(data => expect(data).to.deep.equal(output.product));
+  });
+
   it('updates a product', () => {
     const input = fixtures.req.update;
     const output = fixtures.res.update;
 
-    productApiScope
+    standardScope
       .put('/admin/products/632910392.json', input)
       .reply(200, output);
 
     return shopify.product.update(632910392, input.product)
+      .then(data => expect(data).to.deep.equal(output.product));
+  });
+
+  it('updates a product with presentment option', () => {
+    const input = fixtures.req.update;
+    const output = fixtures.res.update;
+
+    presentmentApiScope
+      .put('/admin/products/632910392.json', input)
+      .reply(200, output);
+
+    return shopifyWithPresenmentOption.product.update(632910392, input.product)
       .then(data => expect(data).to.deep.equal(output.product));
   });
 

--- a/test/shopify.test.js
+++ b/test/shopify.test.js
@@ -47,7 +47,8 @@ describe('Shopify', () => {
     expect(shopify.baseUrl).to.deep.equal({
       auth: `${apiKey}:${password}`,
       hostname: shopName,
-      protocol: 'https:'
+      protocol: 'https:',
+      headers: {}
     });
   });
 
@@ -57,7 +58,8 @@ describe('Shopify', () => {
     expect(shopify.baseUrl).to.deep.equal({
       hostname: `${shopName}.myshopify.com`,
       auth: `${apiKey}:${password}`,
-      protocol: 'https:'
+      protocol: 'https:',
+      headers: {}
     });
   });
 
@@ -67,7 +69,8 @@ describe('Shopify', () => {
     expect(shopify.baseUrl).to.deep.equal({
       hostname: `${shopName}.myshopify.com`,
       protocol: 'https:',
-      auth: false
+      auth: false,
+      headers: {}
     });
   });
 


### PR DESCRIPTION
This is a quick fix to add an option while instantiating the Shopify object so the necessary header will be included to get the presentment prices.