### PR TITLE
add interface params to IInventoryItem

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1551,6 +1551,9 @@ declare namespace Shopify {
     tracked: boolean;
     created_at: string;
     updated_at: string;
+    requires_shipping: boolean;
+    country_code_of_origin: string;
+    harmonized_system_code: string;
   }
 
   interface IInventoryLevel {


### PR DESCRIPTION
adds 'country_code_of_origin', 'harmonized_system_code', and 'requires_shipping' to `IInventoryItem`