### PR TITLE
add `tax_code: string;` to `IProductVariant`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2118,6 +2118,7 @@ declare namespace Shopify {
     requires_shipping: boolean;
     sku: string;
     taxable: boolean;
+    tax_code: string;
     title: string;
     updated_at: string;
     weight: number;


### PR DESCRIPTION
update index.d.ts: add `tax_code: string;` to `IProductVariant`. When not present, shopify returns an empty string `''`