### PR TITLE
typings: tax_code should be nullable

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2142,7 +2142,7 @@ declare namespace Shopify {
     requires_shipping: boolean;
     sku: string;
     taxable: boolean;
-    tax_code: string;
+    tax_code: string | null;
     title: string;
     updated_at: string;
     weight: number;


### PR DESCRIPTION
Minor error in the TypeScript definition:

In GraphQL this field is not required https://help.shopify.com/en/api/graphql-admin-api/reference/object/productvariant#taxcode-2019-10
and the JSON API docs suggest this as well:
> This parameter applies only to the stores that have the Avalara AvaTax app installed

~ https://help.shopify.com/en/api/reference/products/product-variant#tax-code-property-2019-10