### PR TITLE
Adding provinces to the file definition of IShippingZoneCountry

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2377,6 +2377,7 @@ declare namespace Shopify {
     tax_percentage: number;
     tax_type: any | null;
     shipping_zone_id: number;
+    provinces: IProvince[];
   }
 
   interface IShippingZone {


### PR DESCRIPTION
Currently the API returns provinces but the type definitions for IShippingZoneCountry does not contain it. This PR fixes that issue.