### PR TITLE
ICheckout's applied discount property is an object

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -717,7 +717,7 @@ declare namespace Shopify {
 
   interface ICheckout {
     abandoned_checkout_url: string;
-    applied_discount?: ICheckoutDiscount[];
+    applied_discount?: ICheckoutDiscount;
     billing_address?: ICustomerAddress;
     buyer_accepts_marketing: boolean;
     cancel_reason?: 'customer' | 'fraud' | 'inventory' | 'other' | null;


### PR DESCRIPTION
Although not documented, I can confirm from ~50k checkouts that `ICheckout.applied_discount` is a `ICheckoutDiscount` object not an array.