### PR TITLE
Added check for graphql extensions.cost.throttleStatus

### DIFF
--- a/index.js
+++ b/index.js
@@ -229,7 +229,7 @@ Shopify.prototype.graphql = function graphql(data, variables) {
   }
 
   return got(uri, options).then((res) => {
-    if (res.body.extensions && res.body.extensions.cost) {
+    if (res.body.extensions && res.body.extensions.cost && res.body.extensions.cost.throttleStatus) {
       this.updateGraphqlLimits(res.body.extensions.cost.throttleStatus);
     }
 

--- a/index.js
+++ b/index.js
@@ -186,7 +186,7 @@ Shopify.prototype.request = function request(uri, method, key, data, headers) {
  */
 Shopify.prototype.updateGraphqlLimits = function updateGraphqlLimits(throttle) {
   if (!throttle) return;
-  
+
   const limits = this.callGraphqlLimits;
 
   limits.remaining = throttle.currentlyAvailable;

--- a/index.js
+++ b/index.js
@@ -185,6 +185,8 @@ Shopify.prototype.request = function request(uri, method, key, data, headers) {
  * @private
  */
 Shopify.prototype.updateGraphqlLimits = function updateGraphqlLimits(throttle) {
+  if (!throttle) return;
+  
   const limits = this.callGraphqlLimits;
 
   limits.remaining = throttle.currentlyAvailable;
@@ -229,7 +231,7 @@ Shopify.prototype.graphql = function graphql(data, variables) {
   }
 
   return got(uri, options).then((res) => {
-    if (res.body.extensions && res.body.extensions.cost && res.body.extensions.cost.throttleStatus) {
+    if (res.body.extensions && res.body.extensions.cost) {
       this.updateGraphqlLimits(res.body.extensions.cost.throttleStatus);
     }
 


### PR DESCRIPTION
Shopify doesn't return throttleStatus for "staff" plan which causes the error below.

TypeError: Cannot read property 'currentlyAvailable' of undefined
    at Shopify.updateGraphqlLimits (/var/app/current/node_modules/shopify-api-node/index.js:191:31)
    at /var/app/current/node_modules/shopify-api-node/index.js:234:12
    at tryCatcher (/var/app/current/node_modules/bluebird/js/release/util.js:16:23)