### PR TITLE
[fix] Add redirect hook for authorized redirect when using apKey/pass…

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,6 +119,13 @@ Shopify.prototype.request = function request(uri, method, key, data, headers) {
     timeout: this.options.timeout,
     responseType: 'json',
     retry: 0,
+    hooks: {
+      beforeRedirect: [
+        (options) => {
+          options.url.href = `${options.url.protocol}//${this.options.apiKey}:${this.options.password}@${options.url.hostname}${options.url.pathname}`;
+        }
+      ]
+    },
     method
   };
 


### PR DESCRIPTION
When using apiKey/password authentication in a private app, if the Shopify API returns a 303  (for instance when using `discountCode.lookup()`) then `got` follows the redirection without the apiKey & password. This behavior makes `discountCode.lookup()` return a 401 error.

To avoid the unauthorized request, a `beforeRedirect` hook is added to the `got` options.
When a redirect is followed, the API credentials are added to the followed href.