### PR TITLE
[fix] Add missing price rule typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2202,7 +2202,20 @@ declare namespace Shopify {
   }
 
   interface IPriceRulePrerequisiteSubtotalRange {
-    prerequisite_subtotal_range: string;
+    greater_than_or_equal_to: string;
+  }
+
+  interface IPriceRulePrerequisiteQuantityRange {
+    greater_than_or_equal_to: string;
+  }
+
+  interface IPriceRulePrerequisiteToEntitlementQuantityRange {
+    prerequisite_quantity: number | null;
+    entitled_quantity: number | null;
+  }
+
+  interface IPriceRulePrerequisiteShippingPriceRange {
+    less_than_or_equal_to: string;
   }
 
   type PriceRuleTargetType = 'line_item' | 'shipping_line';
@@ -2212,7 +2225,6 @@ declare namespace Shopify {
   type PriceRuleCustomerSelection = 'all' | 'prerequisite';
 
   interface IPriceRule {
-    created_at: string;
     id: number;
     title: string;
     target_type: PriceRuleTargetType;
@@ -2222,16 +2234,26 @@ declare namespace Shopify {
     value: string;
     once_per_customer: boolean;
     usage_limit: number | null;
+    allocation_limit: number | null;
     customer_selection: PriceRuleCustomerSelection;
     prerequisite_saved_search_ids: number[];
     prerequisite_subtotal_range: IPriceRulePrerequisiteSubtotalRange | null;
-    prerequisite_shipping_price_range: string;
+    prerequisite_shipping_price_range: IPriceRulePrerequisiteShippingPriceRange | null;
+    prerequisite_quantity_range: IPriceRulePrerequisiteQuantityRange | null;
+    prerequisite_to_entitlement_quantity_ratio: IPriceRulePrerequisiteToEntitlementQuantityRange | null;
+    prerequisite_product_ids: number[];
+    prerequisite_variant_ids: number[];
+    prerequisite_collection_ids: number[];
+    prerequisite_customer_ids: number[];
     entitled_product_ids: number[];
     entitled_variant_ids: number[];
     entitled_collection_ids: number[];
     entitled_country_ids: number[];
+    created_at: string;
+    updated_at: string;
     starts_at: string;
     ends_at: string;
+    admin_graphql_api_id: string;
   }
 
   interface IProductOption {

--- a/test/shopify.test.js
+++ b/test/shopify.test.js
@@ -722,6 +722,23 @@ describe('Shopify', () => {
       });
     });
 
+    it('does not update callGraphqlLimits if throttleStatus is missing', () => {
+      scope.post('/admin/api/graphql.json').reply(200, {
+        extensions: {
+          cost: {}
+        }
+      });
+
+      return shopify.graphql('query').then(() => {
+        expect(shopify.callGraphqlLimits).to.deep.equal({
+          restoreRate: 50.0,
+          remaining: 997,
+          current: 3,
+          max: 1000.0
+        });
+      });
+    });
+
     it('returns a valid response when using graphql endpoint (1/2)', () => {
       const response = {
         data: { foo: 'bar' }


### PR DESCRIPTION
The `IPriceRule` interface was missing properties returned by the current [Shopify Admin API price rule request](https://shopify.dev/docs/admin-api/rest/reference/discounts/pricerule?api[version]=2020-07#)

- Added missing typings for `IPriceRule` to match current API response data
- Added test for `Shopify.prototype.updateGraphqlLimits()` and undefined arguments to meet coverage