### PR TITLE
[fix] Add missing accept header

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,10 @@ function Shopify(options) {
     protocol: 'https:'
   };
 
-  this.baseHeaders = { 'User-Agent': `${pkg.name}/${pkg.version}` };
+  this.baseHeaders = {
+    'User-Agent': `${pkg.name}/${pkg.version}`,
+    Accept: 'application/json'
+  };
 
   if (options.accessToken) {
     this.baseHeaders['X-Shopify-Access-Token'] = options.accessToken;

--- a/test/shopify.test.js
+++ b/test/shopify.test.js
@@ -58,7 +58,8 @@ describe('Shopify', () => {
       'User-Agent': `${pkg.name}/${pkg.version}`,
       Authorization:
         'Basic YmM3MzFlNTAwODQwMjMxZGE1YjQzYmIzZjM4OGQyZjA6NzIyOTdkOTcxMjcxYm' +
-        'M2MmNhODk5YmJhNzQzMmFjYjE='
+        'M2MmNhODk5YmJhNzQzMmFjYjE=',
+      Accept: 'application/json'
     });
   });
 
@@ -67,7 +68,8 @@ describe('Shopify', () => {
 
     expect(shopify.baseHeaders).to.deep.equal({
       'User-Agent': `${pkg.name}/${pkg.version}`,
-      'X-Shopify-Access-Token': 'f85632530bf277ec9ac6f649fc327f17'
+      'X-Shopify-Access-Token': 'f85632530bf277ec9ac6f649fc327f17',
+      Accept: 'application/json'
     });
   });
 
@@ -510,7 +512,8 @@ describe('Shopify', () => {
     const scope = nock(`https://${shopName}.myshopify.com`, {
       reqheaders: {
         'User-Agent': `${pkg.name}/${pkg.version}`,
-        'X-Shopify-Access-Token': accessToken
+        'X-Shopify-Access-Token': accessToken,
+        Accept: 'application/json'
       }
     });
 


### PR DESCRIPTION
Some endpoints, such as DiscountCode lookup, require the `Accept=application/json` header to be present. The current implementation does not appear to provide the Accept header, returning a `404` when requests are made.

- Added `Accept:'application/json'` to `baseHeaders` so that it's mapped into all requests by default.
- Updated tests to check for the presence of this `Accept` header