### PR TITLE
[api] Add createV2 action to Fulfillment resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ This feature is only available on version 2.24.0 and above.
   - `complete(orderId, id)`
   - `count(orderId[, params)`
   - `create(orderId, params)`
+  - `createV2(params)`
   - `get(orderId, id[, params])`
   - `list(orderId[, params])`
   - `open(orderId, id)`

--- a/index.d.ts
+++ b/index.d.ts
@@ -277,6 +277,7 @@ declare class Shopify {
     complete: (orderId: number, id: number) => Promise<Shopify.IFulfillment>;
     count: (orderId: number, params?: any) => Promise<number>;
     create: (orderId: number, params: any) => Promise<Shopify.IFulfillment>;
+    createV2: (params: any) => Promise<Shopify.IFulfillment>;
     get: (
       orderId: number,
       id: number,

--- a/resources/fulfillment.js
+++ b/resources/fulfillment.js
@@ -3,6 +3,7 @@
 const assign = require('lodash/assign');
 const omit = require('lodash/omit');
 
+const base = require('../mixins/base');
 const baseChild = require('../mixins/base-child');
 
 /**
@@ -65,6 +66,19 @@ Fulfillment.prototype.cancel = function cancel(orderId, id) {
   return this.shopify
     .request(url, 'POST', undefined, {})
     .then((body) => body[this.key]);
+};
+
+/**
+ * Creates a fulfillment for one or many fulfillment orders.
+ * The fulfillment orders are associated with the same order and are assigned to the same location.
+ *
+ * @param {Object} [params] Query parameters
+ * @return {Promise} Promise that resolves with the result
+ * @public
+ */
+Fulfillment.prototype.createV2 = function createV2(params) {
+  const url = base.buildUrl.call(this);
+  return this.shopify.request(url, 'POST', this.key, params);
 };
 
 module.exports = Fulfillment;

--- a/resources/fulfillment.js
+++ b/resources/fulfillment.js
@@ -70,7 +70,8 @@ Fulfillment.prototype.cancel = function cancel(orderId, id) {
 
 /**
  * Creates a fulfillment for one or many fulfillment orders.
- * The fulfillment orders are associated with the same order and are assigned to the same location.
+ * The fulfillment orders are associated with the same order and are assigned to
+ * the same location.
  *
  * @param {Object} [params] Query parameters
  * @return {Promise} Promise that resolves with the result

--- a/test/fixtures/fulfillment/req/createV2.json
+++ b/test/fixtures/fulfillment/req/createV2.json
@@ -1,0 +1,22 @@
+{
+  "fulfillment": {
+    "message": "The package was shipped this morning.",
+    "notify_customer": false,
+    "tracking_info": {
+      "number": 1562678,
+      "url": "https://www.example.com",
+      "company": "example"
+    },
+    "line_items_by_fulfillment_order": [
+      {
+        "fulfillment_order_id": 1046000799,
+        "fulfillment_order_line_items": [
+          {
+            "id": 1025578644,
+            "quantity": 1
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/fixtures/fulfillment/req/index.js
+++ b/test/fixtures/fulfillment/req/index.js
@@ -1,4 +1,5 @@
 'use strict';
 
 exports.create = require('./create');
+exports.createV2 = require('./createV2');
 exports.update = require('./update');

--- a/test/fixtures/fulfillment/res/createV2.json
+++ b/test/fixtures/fulfillment/res/createV2.json
@@ -1,0 +1,69 @@
+{
+  "fulfillment": {
+    "id": 1022782903,
+    "order_id": 1073459976,
+    "status": "success",
+    "created_at": "2020-10-06T14:07:19-04:00",
+    "service": "manual",
+    "updated_at": "2020-10-06T14:07:19-04:00",
+    "tracking_company": "example",
+    "shipment_status": null,
+    "location_id": 48752903,
+    "line_items": [
+      {
+        "id": 1071823189,
+        "variant_id": 389013007,
+        "title": "Crappy Shoes - Red",
+        "quantity": 1,
+        "sku": "crappy_shoes_red",
+        "variant_title": "Small",
+        "vendor": null,
+        "fulfillment_service": "manual",
+        "product_id": 910489600,
+        "requires_shipping": true,
+        "taxable": true,
+        "gift_card": false,
+        "name": "Crappy Shoes - Red - Small",
+        "variant_inventory_management": null,
+        "properties": [],
+        "product_exists": true,
+        "fulfillable_quantity": 0,
+        "grams": 10,
+        "price": "10.00",
+        "total_discount": "0.00",
+        "fulfillment_status": "fulfilled",
+        "price_set": {
+          "shop_money": {
+            "amount": "10.00",
+            "currency_code": "USD"
+          },
+          "presentment_money": {
+            "amount": "10.00",
+            "currency_code": "USD"
+          }
+        },
+        "total_discount_set": {
+          "shop_money": {
+            "amount": "0.00",
+            "currency_code": "USD"
+          },
+          "presentment_money": {
+            "amount": "0.00",
+            "currency_code": "USD"
+          }
+        },
+        "discount_allocations": [],
+        "duties": [],
+        "admin_graphql_api_id": "gid://shopify/LineItem/1071823189",
+        "tax_lines": []
+      }
+    ],
+    "tracking_number": "1562678",
+    "tracking_numbers": ["1562678"],
+    "tracking_url": "https://www.example.com",
+    "tracking_urls": ["https://www.example.com"],
+    "receipt": {},
+    "name": "#1033.2",
+    "admin_graphql_api_id": "gid://shopify/Fulfillment/1022782903"
+  }
+}

--- a/test/fixtures/fulfillment/res/index.js
+++ b/test/fixtures/fulfillment/res/index.js
@@ -4,6 +4,7 @@ exports.complete = require('./complete');
 exports.open = require('./open');
 exports.cancel = require('./cancel');
 exports.create = require('./create');
+exports.createV2 = require('./createV2');
 exports.update = require('./update');
 exports.list = require('./list');
 exports.get = require('./get');

--- a/test/fulfillment.test.js
+++ b/test/fulfillment.test.js
@@ -81,7 +81,7 @@ describe('Shopify#fulfillment', () => {
       .then((data) => expect(data).to.deep.equal(output.fulfillment));
   });
 
-  it('create a fulfillment for an order', () => {
+  it('creates a fulfillment for an order', () => {
     const input = fixtures.req.create;
     const output = fixtures.res.create;
 
@@ -94,7 +94,7 @@ describe('Shopify#fulfillment', () => {
       .then((data) => expect(data).to.deep.equal(output.fulfillment));
   });
 
-  it('create a fulfillment for one or many fulfillment orders', () => {
+  it('creates a fulfillment for one or many fulfillment orders', () => {
     const input = fixtures.req.createV2;
     const output = fixtures.res.createV2;
 

--- a/test/fulfillment.test.js
+++ b/test/fulfillment.test.js
@@ -94,6 +94,17 @@ describe('Shopify#fulfillment', () => {
       .then((data) => expect(data).to.deep.equal(output.fulfillment));
   });
 
+  it('create a fulfillment for one or many fulfillment orders', () => {
+    const input = fixtures.req.createV2;
+    const output = fixtures.res.createV2;
+
+    scope.post('/admin/fulfillments.json', input).reply(201, output);
+
+    return shopify.fulfillment
+      .createV2(input.fulfillment)
+      .then((data) => expect(data).to.deep.equal(output.fulfillment));
+  });
+
   it('updates a fulfillment', () => {
     const input = fixtures.req.update;
     const output = fixtures.res.update;


### PR DESCRIPTION
This PR adds method `shopify.fulfillment.createV2(params)` (without specifying order id) which calls `POST /admin/api/[api-version]/fulfillments.json`. This is the new and recommended way of creating new fulfillments without specifying an order id.

I decided to call it `createV2` because that's how Shopify calls the equivalent graphql mutation.

More info: https://shopify.dev/tutorials/manage-fulfillments-with-fulfillment-and-fulfillmentorder-resources
REST API Docs: https://shopify.dev/docs/admin-api/rest/reference/shipping-and-fulfillment/fulfillment#createV2-2020-10
Graphql Docs: https://shopify.dev/docs/admin-api/graphql/reference/mutation/fulfillmentcreatev2

Fixes #418 