### PR TITLE
[ts] Fix variant / checkout line item compare_at_price: may be null

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -786,7 +786,7 @@ declare namespace Shopify {
 
   interface ICheckoutLineItem {
     applied_discounts: any[];
-    compare_at_price: string;
+    compare_at_price: string | null;
     destination_location_id: number;
     discount_codes: any[];
     fulfillment_service: 'api' | 'custom' | 'legacy' | 'manual';
@@ -2305,7 +2305,7 @@ declare namespace Shopify {
 
   interface IProductVariant {
     barcode: string;
-    compare_at_price: string;
+    compare_at_price: string | null;
     created_at: string;
     fulfillment_service: string;
     grams: number;


### PR DESCRIPTION
Currently the `compare_at_price` field of product variants and checkout line items are typed as required strings. However, when there is no “compare at” price, the value `null` will be present in the field.