### PR TITLE
[fix] fix inventory item interface types;

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1766,6 +1766,11 @@ declare namespace Shopify {
     processed_at: string;
   }
 
+  interface IInventoryItemCountryHarmonizedSystemCode {
+    harmonized_system_code: string | null;
+    country_code: string | null;
+  }
+
   interface IInventoryItem {
     id: number;
     sku: string;
@@ -1773,8 +1778,11 @@ declare namespace Shopify {
     created_at: string;
     updated_at: string;
     requires_shipping: boolean;
-    country_code_of_origin: string;
-    harmonized_system_code: string;
+    cost: string | null;
+    country_code_of_origin: string | null;
+    province_code_of_origin: string | null;
+    harmonized_system_code: string | null;
+    country_harmonized_system_codes: IInventoryItemCountryHarmonizedSystemCode[];
   }
 
   interface IInventoryLevel {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1767,8 +1767,8 @@ declare namespace Shopify {
   }
 
   interface IInventoryItemCountryHarmonizedSystemCode {
-    harmonized_system_code: string | null;
-    country_code: string | null;
+    harmonized_system_code: string;
+    country_code: string;
   }
 
   interface IInventoryItem {


### PR DESCRIPTION
This should fix some existing properties types from the Inventory Item interface, such as `country_code_of_origin` and `harmonized_system_code` possibly being null and add `cost`, `province_code_of_origin` and `country_harmonized_system_codes`.

It's linked to this issue: https://github.com/MONEI/Shopify-api-node/issues/425