### PR TITLE
Adding missing type for fulfillmentOrder

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1690,6 +1690,7 @@ declare namespace Shopify {
     line_items: IFulfillmentOrderLineItem[];
     merchant_requests: IFulfillmentOrderMerchantRequest[];
     order_id: number;
+    fulfillment_service_handle: string;
     request_status: FulfillmentOrderRequestStatus;
     shop_id: number;
     status: FulfillmentOrderStatus;


### PR DESCRIPTION
fulfillment_service_handle https://shopify.dev/docs/admin-api/rest/reference/shipping-and-fulfillment/fulfillmentorder#index-2020-10

Fixes #435 