### PR TITLE
This enables usage of pagination for orders and products

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -429,7 +429,7 @@ declare class Shopify {
     delete: (id: number) => Promise<any>;
     fulfillmentOrders: (id: number) => Promise<Shopify.IFulfillmentOrder[]>;
     get: (id: number, params?: any) => Promise<Shopify.IOrder>;
-    list: (params?: any) => Promise<Shopify.IOrder[]>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IOrder>>;
     open: (id: number) => Promise<Shopify.IOrder>;
     update: (id: number, params: any) => Promise<Shopify.IOrder>;
   };
@@ -477,7 +477,7 @@ declare class Shopify {
     create: (params: any) => Promise<Shopify.IProduct>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.IProduct>;
-    list: (params?: any) => Promise<Shopify.IProduct[]>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IProduct>>;
     update: (id: number, params: any) => Promise<Shopify.IProduct>;
   };
   productImage: {
@@ -2167,6 +2167,11 @@ declare namespace Shopify {
     total_weight: number;
     updated_at: string;
     user_id: number | null;
+  }
+
+  interface IPaginatedResult<T> extends Array<T> {
+    nextPageParameters?: any;
+    previousPageParameters?: any;
   }
 
   type OrderRisksRecommendation = 'accept' | 'investigate' | 'cancel';

--- a/index.d.ts
+++ b/index.d.ts
@@ -188,7 +188,9 @@ declare class Shopify {
     create: (params: any) => Promise<Shopify.ICustomer>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.ICustomer>;
-    list: (params?: any) => Promise<Shopify.ICustomer[]>;
+    list: (
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.ICustomer>>;
     search: (params: any) => Promise<any>;
     update: (id: number, params: any) => Promise<Shopify.ICustomer>;
     orders: (id: number, params?: any) => Promise<Shopify.IOrder[]>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2136,6 +2136,7 @@ declare namespace Shopify {
     phone: string;
     presentment_currency: string;
     processed_at: string;
+    checkout_id: number;
     processing_method: OrderProcessingMethod;
     referring_site: string;
     refunds: IRefund[];


### PR DESCRIPTION
No original work here. It´s basically what @YourWishes suggests in #288.
Could and should be extended throughout the api for lists.

Usage example:
```
  const orderList: IOrder[] = [];
  const orderStatus = 'any';

  let params = { status: orderStatus, limit: 250 };

  do {
    const orders = await shopify.order.list(params);

    for (const order of orders) {
      orderList.push(order);
    }

    params = orders.nextPageParameters;
  } while (params !== undefined);

  console.log(`after while loop len:${orderList.length}`)
```