### PR TITLE
Applied Discounts do not match Shopify documentation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1447,7 +1447,7 @@ declare namespace Shopify {
   type DraftOrderLineItemFulfullmentStatus = 'fulfilled' | 'partial';
 
   interface IDraftOrderLineItem {
-    applied_discounts: any[] | null;
+    applied_discount: IDraftOrderDiscount | null;
     discount_codes: any[];
     fulfillment_service: DraftOrderLineItemFulfullmentService;
     fulfillment_status?: DraftOrderLineItemFulfullmentStatus | null;
@@ -1472,7 +1472,7 @@ declare namespace Shopify {
   }
 
   interface IDraftOrder {
-    applied_discount: IDraftOrderDiscount[];
+    applied_discount: IDraftOrderDiscount | null;
     billing_address: ICustomerAddress;
     completed_at: string | null;
     created_at: string;


### PR DESCRIPTION
When adding an applied discount to a draft order or a draft order line item, you can only pass in a single discount.  Arrays don't seem to be accepted.

Reference: https://shopify.dev/docs/admin-api/rest/reference/orders/draftorder#create-2020-04