### PR TITLE
Add "cache" property to ScriptTag interfaces

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2529,6 +2529,7 @@ declare namespace Shopify {
     id: number;
     src: string;
     display_scope: ScriptTagDisplayScope;
+    cache: boolean;
     updated_at: string;
   }
 
@@ -2536,12 +2537,14 @@ declare namespace Shopify {
     event: ScriptTagEvent;
     src: string;
     display_scope?: ScriptTagDisplayScope;
+    cache?: boolean;
   }
 
   interface IUpdateScriptTag {
     event: ScriptTagEvent;
     src: string;
     display_scope?: ScriptTagDisplayScope;
+    cache?: boolean;
   }
 
   interface ICarrierShippingRateProvider {


### PR DESCRIPTION
Hey folks - I updated the TypeScript definitions to include the ScriptTag `cache` property, as seen in the [docs](https://shopify.dev/docs/admin-api/rest/reference/online-store/scripttag) for API version 2021-01.