### PR TITLE
Implemented IPaginatedResult for supported endpoints

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -531,7 +531,7 @@ declare class Shopify {
     create: (params: any) => Promise<Shopify.IProduct>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.IProduct>;
-    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IProduct>>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IProduct[]>>;
     update: (id: number, params: any) => Promise<Shopify.IProduct>;
   };
   productImage: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,7 +42,7 @@ declare class Shopify {
       params: Shopify.ICreateApplicationCharge
     ) => Promise<Shopify.IApplicationCharge>;
     get: (id: number, params?: any) => Promise<Shopify.IApplicationCharge>;
-    list: (params?: any) => Promise<Shopify.IApplicationCharge[]>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IApplicationCharge[]>>;
   };
   applicationCredit: {
     create: (
@@ -64,7 +64,7 @@ declare class Shopify {
       id: number,
       params?: any
     ) => Promise<Shopify.IArticle>;
-    list: (blogId: number, params?: any) => Promise<Shopify.IArticle[]>;
+    list: (blogId: number, params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IArticle[]>>;
     tags: (blogId?: number, params?: any) => Promise<string[]>;
     update: (
       blogId: number,
@@ -84,14 +84,14 @@ declare class Shopify {
   };
   balance: {
     list: () => Promise<Shopify.IBalance[]>;
-    transactions: () => Promise<Shopify.IBalanceTransaction[]>;
+    transactions: () => Promise<Shopify.IPaginatedResult<Shopify.IBalanceTransaction[]>>;
   };
   blog: {
     count: () => Promise<number>;
     create: (params: Shopify.ICreateBlog) => Promise<Shopify.IBlog>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.IBlog>;
-    list: (params?: any) => Promise<Shopify.IBlog[]>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IBlog[]>>;
     update: (id: number, params: any) => Promise<Shopify.IBlog>;
   };
   cancellationRequest: {
@@ -134,15 +134,15 @@ declare class Shopify {
     create: (params: Shopify.ICreateCollect) => Promise<Shopify.ICollect>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.ICollect>;
-    list: (params?: any) => Promise<Shopify.ICollect[]>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.ICollect[]>>;
   };
   collection: {
     get: (id: number, params?: any) => Promise<Shopify.ICollection>;
-    products: (id: number, params?: any) => Promise<Shopify.IProduct[]>;
+    products: (id: number, params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IProduct[]>>;
   };
   collectionListing: {
     get: (id: number, params?: any) => Promise<Shopify.ICollectionListing>;
-    list: (params?: any) => Promise<Shopify.ICollectionListing[]>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.ICollectionListing[]>>;
     productIds: (id: number, params?: any) => Promise<any>;
   };
   comment: {
@@ -150,7 +150,7 @@ declare class Shopify {
     count: (params?: any) => Promise<number>;
     create: (params: Shopify.ICreateComment) => Promise<Shopify.IComment>;
     get: (id: number, params?: any) => Promise<Shopify.IComment>;
-    list: (params?: any) => Promise<Shopify.IComment[]>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IComment[]>>;
     notSpam: (id: number) => Promise<Shopify.IComment>;
     remove: (id: number) => Promise<Shopify.IComment>;
     restore: (id: number) => Promise<Shopify.IComment>;
@@ -179,7 +179,7 @@ declare class Shopify {
     create: (params: any) => Promise<Shopify.ICustomCollection>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.ICustomCollection>;
-    list: (params?: any) => Promise<Shopify.ICustomCollection[]>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.ICustomCollection[]>>;
     update: (id: number, params: any) => Promise<Shopify.ICustomCollection>;
   };
   customer: {
@@ -190,8 +190,8 @@ declare class Shopify {
     get: (id: number, params?: any) => Promise<Shopify.ICustomer>;
     list: (
       params?: any
-    ) => Promise<Shopify.IPaginatedResult<Shopify.ICustomer>>;
-    search: (params: any) => Promise<any>;
+    ) => Promise<Shopify.IPaginatedResult<Shopify.ICustomer[]>>;
+    search: (params: any) => Promise<Shopify.IPaginatedResult<Shopify.ICustomer[]>>;
     sendInvite: (
       id: number,
       params?: Shopify.ICustomerSendInvite
@@ -213,7 +213,7 @@ declare class Shopify {
     list: (
       customerId: number,
       params?: any
-    ) => Promise<Shopify.ICustomerAddress[]>;
+    ) => Promise<Shopify.IPaginatedResult<Shopify.ICustomerAddress[]>>;
     set: (customerId: number, params: any) => Promise<any>;
     update: (
       customerId: number,
@@ -227,7 +227,7 @@ declare class Shopify {
     customers: (id: number, params?: any) => Promise<any>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.ICustomerSavedSearch>;
-    list: (params?: any) => Promise<Shopify.ICustomerSavedSearch[]>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.ICustomerSavedSearch[]>>;
     update: (id: number, params: any) => Promise<Shopify.ICustomerSavedSearch>;
   };
   discountCode: {
@@ -240,7 +240,7 @@ declare class Shopify {
     list: (
       priceRuleId: number,
       params?: any
-    ) => Promise<Shopify.IDiscountCode[]>;
+    ) => Promise<Shopify.IPaginatedResult<Shopify.IDiscountCode[]>>;
     lookup: (params: any) => Promise<Shopify.IDiscountCode>;
     update: (
       priceRuleId: number,
@@ -261,7 +261,7 @@ declare class Shopify {
   };
   dispute: {
     get: (id: number) => Promise<Shopify.IDispute>;
-    list: (params?: any) => Promise<Shopify.IDispute[]>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IDispute[]>>;
   };
   draftOrder: {
     complete: (id: number, params?: any) => Promise<Shopify.IDraftOrder>;
@@ -269,14 +269,14 @@ declare class Shopify {
     create: (params: any) => Promise<Shopify.IDraftOrder>;
     delete: (id: number) => Promise<void>;
     get: (id: number) => Promise<Shopify.IDraftOrder>;
-    list: (params?: any) => Promise<Shopify.IDraftOrder[]>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IDraftOrder[]>>;
     sendInvoice: (id: number, params?: any) => Promise<any>;
     update: (id: number, params?: any) => Promise<Shopify.IDraftOrder>;
   };
   event: {
     count: (params?: any) => Promise<number>;
     get: (id: number, params?: any) => Promise<Shopify.IEvent>;
-    list: (params?: any) => Promise<Shopify.IEvent[]>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IEvent[]>>;
   };
   fulfillment: {
     cancel: (orderId: number, id: number) => Promise<Shopify.IFulfillment>;
@@ -289,7 +289,7 @@ declare class Shopify {
       id: number,
       params?: any
     ) => Promise<Shopify.IFulfillment>;
-    list: (orderId: number, params?: any) => Promise<Shopify.IFulfillment[]>;
+    list: (orderId: number, params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IFulfillment[]>>;
     open: (orderId: number, id: number) => Promise<Shopify.IFulfillment>;
     update: (
       orderId: number,
@@ -366,8 +366,8 @@ declare class Shopify {
     create: (params: any) => Promise<Shopify.IGiftCard>;
     disable: (id: number) => Promise<any>;
     get: (id: number) => Promise<Shopify.IGiftCard>;
-    list: (params?: any) => Promise<Shopify.IGiftCard[]>;
-    search: (params: any) => Promise<any>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IGiftCard[]>>;
+    search: (params: any) => Promise<Shopify.IPaginatedResult<Shopify.IGiftCard>>;
     update: (id: number, params: any) => Promise<Shopify.IGiftCard>;
   };
   giftCardAdjustment: {
@@ -384,14 +384,14 @@ declare class Shopify {
   graphql: (data: string, variables?: any) => Promise<any>;
   inventoryItem: {
     get: (id: number) => Promise<Shopify.IInventoryItem>;
-    list: (params?: any) => Promise<Shopify.IInventoryItem[]>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IInventoryItem[]>>;
     update: (id: number, params: any) => Promise<Shopify.IInventoryItem>;
   };
   inventoryLevel: {
     adjust: (params: any) => Promise<Shopify.IInventoryLevel>;
     connect: (params: any) => Promise<Shopify.IInventoryLevel>;
     delete: (params: any) => Promise<void>;
-    list: (params: any) => Promise<Shopify.IInventoryLevel[]>;
+    list: (params: any) => Promise<Shopify.IPaginatedResult<Shopify.IInventoryLevel[]>>;
     set: (params: any) => Promise<Shopify.IInventoryLevel>;
   };
   location: {
@@ -401,14 +401,14 @@ declare class Shopify {
       id: number,
       params?: any
     ) => Promise<Shopify.IInventoryLevel[]>;
-    list: () => Promise<Shopify.ILocation[]>;
+    list: () => Promise<Shopify.IPaginatedResult<Shopify.ILocation[]>>;
   };
   marketingEvent: {
     count: (params?: any) => Promise<number>;
     create: (params: any) => Promise<Shopify.IMarketingEvent>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.IMarketingEvent>;
-    list: (params?: any) => Promise<Shopify.IMarketingEvent[]>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IMarketingEvent[]>>;
     update: (id: number, params: any) => Promise<Shopify.IMarketingEvent>;
     engagements: (id: number, params: any) => Promise<any>;
   };
@@ -417,7 +417,7 @@ declare class Shopify {
     create: (params: any) => Promise<Shopify.IMetafield>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.IMetafield>;
-    list: (params?: any) => Promise<Shopify.IMetafield[]>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IMetafield[]>>;
     update: (id: number, params: any) => Promise<Shopify.IMetafield>;
   };
   on(
@@ -444,7 +444,7 @@ declare class Shopify {
     create: (orderId: number, params: any) => Promise<Shopify.IOrderRisk>;
     delete: (orderId: number, id: number) => Promise<void>;
     get: (orderId: number, id: number) => Promise<Shopify.IOrderRisk>;
-    list: (orderId: number) => Promise<Shopify.IOrderRisk[]>;
+    list: (orderId: number) => Promise<Shopify.IPaginatedResult<Shopify.IOrderRisk[]>>;
     update: (
       orderId: number,
       id: number,
@@ -456,7 +456,7 @@ declare class Shopify {
     create: (params: any) => Promise<Shopify.IPage>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.IPage>;
-    list: (params?: any) => Promise<Shopify.IPage[]>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IPage[]>>;
     update: (id: number, params: any) => Promise<Shopify.IPage>;
   };
   payment: {
@@ -467,7 +467,7 @@ declare class Shopify {
   };
   payout: {
     get: (id: number) => Promise<Shopify.IPayout>;
-    list: (params?: any) => Promise<Shopify.IPayout[]>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IPayout[]>>;
   };
   policy: {
     list: (params?: any) => Promise<Shopify.IPolicy[]>;
@@ -476,7 +476,7 @@ declare class Shopify {
     create: (params: any) => Promise<Shopify.IPriceRule>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.IPriceRule>;
-    list: (params?: any) => Promise<Shopify.IPriceRule[]>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IPriceRule[]>>;
     update: (id: number, params: any) => Promise<Shopify.IPriceRule>;
   };
   product: {
@@ -511,7 +511,7 @@ declare class Shopify {
     ) => Promise<Shopify.IProductListing>;
     delete: (productId: number) => Promise<void>;
     get: (productId: number) => Promise<Shopify.IProductListing>;
-    list: (params?: any) => Promise<Shopify.IProductListing[]>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IProductListing[]>>;
     productIds: (params?: any) => Promise<any>;
   };
   productResourceFeedback: {
@@ -535,7 +535,7 @@ declare class Shopify {
     list: (
       productId: number,
       params?: any
-    ) => Promise<Shopify.IProductVariant[]>;
+    ) => Promise<Shopify.IPaginatedResult<Shopify.IProductVariant[]>>;
     update: (id: number, params: any) => Promise<Shopify.IProductVariant>;
   };
   province: {
@@ -576,7 +576,7 @@ declare class Shopify {
     create: (params: Shopify.ICreateRedirect) => Promise<Shopify.IRedirect>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.IRedirect>;
-    list: (params?: any) => Promise<Shopify.IRedirect[]>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IRedirect[]>>;
     update: (
       id: number,
       params: Shopify.IUpdateRedirect
@@ -590,13 +590,13 @@ declare class Shopify {
       id: number,
       params?: any
     ) => Promise<Shopify.IRefund>;
-    list: (orderId: number, params?: any) => Promise<Shopify.IRefund[]>;
+    list: (orderId: number, params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IRefund[]>>;
   };
   report: {
     create: (params: any) => Promise<Shopify.IReport>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.IReport>;
-    list: (params?: any) => Promise<Shopify.IReport[]>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IReport[]>>;
     update: (id: number, params: any) => Promise<Shopify.IReport>;
   };
   resourceFeedback: {
@@ -608,7 +608,7 @@ declare class Shopify {
     create: (params: Shopify.ICreateScriptTag) => Promise<Shopify.IScriptTag>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.IScriptTag>;
-    list: (params?: any) => Promise<Shopify.IScriptTag[]>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IScriptTag[]>>;
     update: (
       id: number,
       params: Shopify.IUpdateScriptTag
@@ -625,7 +625,7 @@ declare class Shopify {
     create: (params: any) => Promise<Shopify.ISmartCollection>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.ISmartCollection>;
-    list: (params?: any) => Promise<Shopify.ISmartCollection[]>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.ISmartCollection[]>>;
     order: (id: number, params: any) => Promise<void>;
     products: (id: number, params: any) => Promise<Shopify.IProduct>;
     update: (id: number, params: any) => Promise<Shopify.ISmartCollection>;
@@ -636,7 +636,7 @@ declare class Shopify {
     list: () => Promise<Shopify.IStorefrontAccessToken[]>;
   };
   tenderTransaction: {
-    list: (params?: any) => Promise<Shopify.ITenderTransaction[]>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.ITenderTransaction[]>>;
   };
   theme: {
     create: (params: any) => Promise<Shopify.ITheme>;
@@ -653,7 +653,7 @@ declare class Shopify {
       id: number,
       params?: any
     ) => Promise<Shopify.ITransaction>;
-    list: (orderId: number, params?: any) => Promise<Shopify.ITransaction[]>;
+    list: (orderId: number, params?: any) => Promise<Shopify.IPaginatedResult<Shopify.ITransaction[]>>;
   };
   usageCharge: {
     create: (
@@ -673,14 +673,14 @@ declare class Shopify {
   user: {
     current: () => Promise<Shopify.IUser>;
     get: (id: number) => Promise<Shopify.IUser>;
-    list: () => Promise<Shopify.IUser[]>;
+    list: () => Promise<Shopify.IPaginatedResult<Shopify.IUser[]>>;
   };
   webhook: {
     count: (params?: any) => Promise<number>;
     create: (params: Shopify.ICreateWebhook) => Promise<Shopify.IWebhook>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.IWebhook>;
-    list: (params?: any) => Promise<Shopify.IWebhook[]>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IWebhook[]>>;
     update: (
       id: number,
       params: Shopify.IUpdateWebhook

--- a/index.d.ts
+++ b/index.d.ts
@@ -2232,6 +2232,18 @@ declare namespace Shopify {
     date: string;
     currency: string;
     amount: string;
+    summary: {
+      adjustments_fee_amount: string
+      adjustments_gross_amount: string
+      charges_fee_amount: string
+      charges_gross_amount: string
+      refunds_fee_amount: string
+      refunds_gross_amount: string
+      reserved_funds_fee_amount: string
+      reserved_funds_gross_amount: string
+      retried_payouts_fee_amount: string
+      retried_payouts_gross_amount: string
+    }
   }
 
   interface IPolicy {

--- a/index.d.ts
+++ b/index.d.ts
@@ -531,7 +531,9 @@ declare class Shopify {
     create: (params: any) => Promise<Shopify.IProduct>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.IProduct>;
-    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IProduct[]>>;
+    list: (
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.IProduct[]>>;
     update: (id: number, params: any) => Promise<Shopify.IProduct>;
   };
   productImage: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -132,7 +132,9 @@ declare class Shopify {
     count: (params?: any) => Promise<number>;
     create: (params?: any) => Promise<Shopify.ICheckout>;
     get: (token: string) => Promise<Shopify.ICheckout>;
-    list: (params?: any) => Promise<Shopify.ICheckout[]>;
+    list: (
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.ICheckout[]>>;
     shippingRates: (token: string) => Promise<any>;
     update: (token: any, params: any) => Promise<Shopify.ICheckout>;
   };

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,7 +42,9 @@ declare class Shopify {
       params: Shopify.ICreateApplicationCharge
     ) => Promise<Shopify.IApplicationCharge>;
     get: (id: number, params?: any) => Promise<Shopify.IApplicationCharge>;
-    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IApplicationCharge[]>>;
+    list: (
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.IApplicationCharge[]>>;
   };
   applicationCredit: {
     create: (
@@ -64,7 +66,10 @@ declare class Shopify {
       id: number,
       params?: any
     ) => Promise<Shopify.IArticle>;
-    list: (blogId: number, params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IArticle[]>>;
+    list: (
+      blogId: number,
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.IArticle[]>>;
     tags: (blogId?: number, params?: any) => Promise<string[]>;
     update: (
       blogId: number,
@@ -84,7 +89,9 @@ declare class Shopify {
   };
   balance: {
     list: () => Promise<Shopify.IBalance[]>;
-    transactions: () => Promise<Shopify.IPaginatedResult<Shopify.IBalanceTransaction[]>>;
+    transactions: () => Promise<
+      Shopify.IPaginatedResult<Shopify.IBalanceTransaction[]>
+    >;
   };
   blog: {
     count: () => Promise<number>;
@@ -134,15 +141,22 @@ declare class Shopify {
     create: (params: Shopify.ICreateCollect) => Promise<Shopify.ICollect>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.ICollect>;
-    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.ICollect[]>>;
+    list: (
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.ICollect[]>>;
   };
   collection: {
     get: (id: number, params?: any) => Promise<Shopify.ICollection>;
-    products: (id: number, params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IProduct[]>>;
+    products: (
+      id: number,
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.IProduct[]>>;
   };
   collectionListing: {
     get: (id: number, params?: any) => Promise<Shopify.ICollectionListing>;
-    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.ICollectionListing[]>>;
+    list: (
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.ICollectionListing[]>>;
     productIds: (id: number, params?: any) => Promise<any>;
   };
   comment: {
@@ -150,7 +164,9 @@ declare class Shopify {
     count: (params?: any) => Promise<number>;
     create: (params: Shopify.ICreateComment) => Promise<Shopify.IComment>;
     get: (id: number, params?: any) => Promise<Shopify.IComment>;
-    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IComment[]>>;
+    list: (
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.IComment[]>>;
     notSpam: (id: number) => Promise<Shopify.IComment>;
     remove: (id: number) => Promise<Shopify.IComment>;
     restore: (id: number) => Promise<Shopify.IComment>;
@@ -179,7 +195,9 @@ declare class Shopify {
     create: (params: any) => Promise<Shopify.ICustomCollection>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.ICustomCollection>;
-    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.ICustomCollection[]>>;
+    list: (
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.ICustomCollection[]>>;
     update: (id: number, params: any) => Promise<Shopify.ICustomCollection>;
   };
   customer: {
@@ -191,7 +209,9 @@ declare class Shopify {
     list: (
       params?: any
     ) => Promise<Shopify.IPaginatedResult<Shopify.ICustomer[]>>;
-    search: (params: any) => Promise<Shopify.IPaginatedResult<Shopify.ICustomer[]>>;
+    search: (
+      params: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.ICustomer[]>>;
     sendInvite: (
       id: number,
       params?: Shopify.ICustomerSendInvite
@@ -227,7 +247,9 @@ declare class Shopify {
     customers: (id: number, params?: any) => Promise<any>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.ICustomerSavedSearch>;
-    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.ICustomerSavedSearch[]>>;
+    list: (
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.ICustomerSavedSearch[]>>;
     update: (id: number, params: any) => Promise<Shopify.ICustomerSavedSearch>;
   };
   discountCode: {
@@ -261,7 +283,9 @@ declare class Shopify {
   };
   dispute: {
     get: (id: number) => Promise<Shopify.IDispute>;
-    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IDispute[]>>;
+    list: (
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.IDispute[]>>;
   };
   draftOrder: {
     complete: (id: number, params?: any) => Promise<Shopify.IDraftOrder>;
@@ -269,7 +293,9 @@ declare class Shopify {
     create: (params: any) => Promise<Shopify.IDraftOrder>;
     delete: (id: number) => Promise<void>;
     get: (id: number) => Promise<Shopify.IDraftOrder>;
-    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IDraftOrder[]>>;
+    list: (
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.IDraftOrder[]>>;
     sendInvoice: (id: number, params?: any) => Promise<any>;
     update: (id: number, params?: any) => Promise<Shopify.IDraftOrder>;
   };
@@ -289,7 +315,10 @@ declare class Shopify {
       id: number,
       params?: any
     ) => Promise<Shopify.IFulfillment>;
-    list: (orderId: number, params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IFulfillment[]>>;
+    list: (
+      orderId: number,
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.IFulfillment[]>>;
     open: (orderId: number, id: number) => Promise<Shopify.IFulfillment>;
     update: (
       orderId: number,
@@ -366,8 +395,12 @@ declare class Shopify {
     create: (params: any) => Promise<Shopify.IGiftCard>;
     disable: (id: number) => Promise<any>;
     get: (id: number) => Promise<Shopify.IGiftCard>;
-    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IGiftCard[]>>;
-    search: (params: any) => Promise<Shopify.IPaginatedResult<Shopify.IGiftCard>>;
+    list: (
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.IGiftCard[]>>;
+    search: (
+      params: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.IGiftCard>>;
     update: (id: number, params: any) => Promise<Shopify.IGiftCard>;
   };
   giftCardAdjustment: {
@@ -384,14 +417,18 @@ declare class Shopify {
   graphql: (data: string, variables?: any) => Promise<any>;
   inventoryItem: {
     get: (id: number) => Promise<Shopify.IInventoryItem>;
-    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IInventoryItem[]>>;
+    list: (
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.IInventoryItem[]>>;
     update: (id: number, params: any) => Promise<Shopify.IInventoryItem>;
   };
   inventoryLevel: {
     adjust: (params: any) => Promise<Shopify.IInventoryLevel>;
     connect: (params: any) => Promise<Shopify.IInventoryLevel>;
     delete: (params: any) => Promise<void>;
-    list: (params: any) => Promise<Shopify.IPaginatedResult<Shopify.IInventoryLevel[]>>;
+    list: (
+      params: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.IInventoryLevel[]>>;
     set: (params: any) => Promise<Shopify.IInventoryLevel>;
   };
   location: {
@@ -408,7 +445,9 @@ declare class Shopify {
     create: (params: any) => Promise<Shopify.IMarketingEvent>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.IMarketingEvent>;
-    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IMarketingEvent[]>>;
+    list: (
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.IMarketingEvent[]>>;
     update: (id: number, params: any) => Promise<Shopify.IMarketingEvent>;
     engagements: (id: number, params: any) => Promise<any>;
   };
@@ -417,7 +456,9 @@ declare class Shopify {
     create: (params: any) => Promise<Shopify.IMetafield>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.IMetafield>;
-    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IMetafield[]>>;
+    list: (
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.IMetafield[]>>;
     update: (id: number, params: any) => Promise<Shopify.IMetafield>;
   };
   on(
@@ -444,7 +485,9 @@ declare class Shopify {
     create: (orderId: number, params: any) => Promise<Shopify.IOrderRisk>;
     delete: (orderId: number, id: number) => Promise<void>;
     get: (orderId: number, id: number) => Promise<Shopify.IOrderRisk>;
-    list: (orderId: number) => Promise<Shopify.IPaginatedResult<Shopify.IOrderRisk[]>>;
+    list: (
+      orderId: number
+    ) => Promise<Shopify.IPaginatedResult<Shopify.IOrderRisk[]>>;
     update: (
       orderId: number,
       id: number,
@@ -467,7 +510,9 @@ declare class Shopify {
   };
   payout: {
     get: (id: number) => Promise<Shopify.IPayout>;
-    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IPayout[]>>;
+    list: (
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.IPayout[]>>;
   };
   policy: {
     list: (params?: any) => Promise<Shopify.IPolicy[]>;
@@ -476,7 +521,9 @@ declare class Shopify {
     create: (params: any) => Promise<Shopify.IPriceRule>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.IPriceRule>;
-    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IPriceRule[]>>;
+    list: (
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.IPriceRule[]>>;
     update: (id: number, params: any) => Promise<Shopify.IPriceRule>;
   };
   product: {
@@ -511,7 +558,9 @@ declare class Shopify {
     ) => Promise<Shopify.IProductListing>;
     delete: (productId: number) => Promise<void>;
     get: (productId: number) => Promise<Shopify.IProductListing>;
-    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IProductListing[]>>;
+    list: (
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.IProductListing[]>>;
     productIds: (params?: any) => Promise<any>;
   };
   productResourceFeedback: {
@@ -576,7 +625,9 @@ declare class Shopify {
     create: (params: Shopify.ICreateRedirect) => Promise<Shopify.IRedirect>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.IRedirect>;
-    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IRedirect[]>>;
+    list: (
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.IRedirect[]>>;
     update: (
       id: number,
       params: Shopify.IUpdateRedirect
@@ -590,13 +641,18 @@ declare class Shopify {
       id: number,
       params?: any
     ) => Promise<Shopify.IRefund>;
-    list: (orderId: number, params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IRefund[]>>;
+    list: (
+      orderId: number,
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.IRefund[]>>;
   };
   report: {
     create: (params: any) => Promise<Shopify.IReport>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.IReport>;
-    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IReport[]>>;
+    list: (
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.IReport[]>>;
     update: (id: number, params: any) => Promise<Shopify.IReport>;
   };
   resourceFeedback: {
@@ -608,7 +664,9 @@ declare class Shopify {
     create: (params: Shopify.ICreateScriptTag) => Promise<Shopify.IScriptTag>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.IScriptTag>;
-    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IScriptTag[]>>;
+    list: (
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.IScriptTag[]>>;
     update: (
       id: number,
       params: Shopify.IUpdateScriptTag
@@ -625,7 +683,9 @@ declare class Shopify {
     create: (params: any) => Promise<Shopify.ISmartCollection>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.ISmartCollection>;
-    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.ISmartCollection[]>>;
+    list: (
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.ISmartCollection[]>>;
     order: (id: number, params: any) => Promise<void>;
     products: (id: number, params: any) => Promise<Shopify.IProduct>;
     update: (id: number, params: any) => Promise<Shopify.ISmartCollection>;
@@ -636,7 +696,9 @@ declare class Shopify {
     list: () => Promise<Shopify.IStorefrontAccessToken[]>;
   };
   tenderTransaction: {
-    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.ITenderTransaction[]>>;
+    list: (
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.ITenderTransaction[]>>;
   };
   theme: {
     create: (params: any) => Promise<Shopify.ITheme>;
@@ -653,7 +715,10 @@ declare class Shopify {
       id: number,
       params?: any
     ) => Promise<Shopify.ITransaction>;
-    list: (orderId: number, params?: any) => Promise<Shopify.IPaginatedResult<Shopify.ITransaction[]>>;
+    list: (
+      orderId: number,
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.ITransaction[]>>;
   };
   usageCharge: {
     create: (
@@ -680,7 +745,9 @@ declare class Shopify {
     create: (params: Shopify.ICreateWebhook) => Promise<Shopify.IWebhook>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.IWebhook>;
-    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IWebhook[]>>;
+    list: (
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.IWebhook[]>>;
     update: (
       id: number,
       params: Shopify.IUpdateWebhook
@@ -2233,17 +2300,17 @@ declare namespace Shopify {
     currency: string;
     amount: string;
     summary: {
-      adjustments_fee_amount: string
-      adjustments_gross_amount: string
-      charges_fee_amount: string
-      charges_gross_amount: string
-      refunds_fee_amount: string
-      refunds_gross_amount: string
-      reserved_funds_fee_amount: string
-      reserved_funds_gross_amount: string
-      retried_payouts_fee_amount: string
-      retried_payouts_gross_amount: string
-    }
+      adjustments_fee_amount: string;
+      adjustments_gross_amount: string;
+      charges_fee_amount: string;
+      charges_gross_amount: string;
+      refunds_fee_amount: string;
+      refunds_gross_amount: string;
+      reserved_funds_fee_amount: string;
+      reserved_funds_gross_amount: string;
+      retried_payouts_fee_amount: string;
+      retried_payouts_gross_amount: string;
+    };
   }
 
   interface IPolicy {

--- a/index.d.ts
+++ b/index.d.ts
@@ -477,7 +477,7 @@ declare class Shopify {
     delete: (id: number) => Promise<any>;
     fulfillmentOrders: (id: number) => Promise<Shopify.IFulfillmentOrder[]>;
     get: (id: number, params?: any) => Promise<Shopify.IOrder>;
-    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IOrder>>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IOrder[]>>;
     open: (id: number) => Promise<Shopify.IOrder>;
     update: (id: number, params: any) => Promise<Shopify.IOrder>;
   };

--- a/index.d.ts
+++ b/index.d.ts
@@ -188,7 +188,9 @@ declare class Shopify {
     create: (params: any) => Promise<Shopify.ICustomer>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.ICustomer>;
-    list: (params?: any) => Promise<Shopify.ICustomer[]>;
+    list: (
+      params?: any
+    ) => Promise<Shopify.IPaginatedResult<Shopify.ICustomer>>;
     search: (params: any) => Promise<any>;
     sendInvite: (
       id: number,

--- a/index.d.ts
+++ b/index.d.ts
@@ -400,7 +400,7 @@ declare class Shopify {
     ) => Promise<Shopify.IPaginatedResult<Shopify.IGiftCard[]>>;
     search: (
       params: any
-    ) => Promise<Shopify.IPaginatedResult<Shopify.IGiftCard>>;
+    ) => Promise<Shopify.IPaginatedResult<Shopify.IGiftCard[]>>;
     update: (id: number, params: any) => Promise<Shopify.IGiftCard>;
   };
   giftCardAdjustment: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -2156,6 +2156,7 @@ declare namespace Shopify {
     phone: string;
     presentment_currency: string;
     processed_at: string;
+    checkout_id: number;
     processing_method: OrderProcessingMethod;
     referring_site: string;
     refunds: IRefund[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -434,7 +434,7 @@ declare class Shopify {
     delete: (id: number) => Promise<any>;
     fulfillmentOrders: (id: number) => Promise<Shopify.IFulfillmentOrder[]>;
     get: (id: number, params?: any) => Promise<Shopify.IOrder>;
-    list: (params?: any) => Promise<Shopify.IOrder[]>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IOrder>>;
     open: (id: number) => Promise<Shopify.IOrder>;
     update: (id: number, params: any) => Promise<Shopify.IOrder>;
   };
@@ -482,7 +482,7 @@ declare class Shopify {
     create: (params: any) => Promise<Shopify.IProduct>;
     delete: (id: number) => Promise<void>;
     get: (id: number, params?: any) => Promise<Shopify.IProduct>;
-    list: (params?: any) => Promise<Shopify.IProduct[]>;
+    list: (params?: any) => Promise<Shopify.IPaginatedResult<Shopify.IProduct>>;
     update: (id: number, params: any) => Promise<Shopify.IProduct>;
   };
   productImage: {
@@ -2187,6 +2187,11 @@ declare namespace Shopify {
     total_weight: number;
     updated_at: string;
     user_id: number | null;
+  }
+
+  interface IPaginatedResult<T> extends Array<T> {
+    nextPageParameters?: any;
+    previousPageParameters?: any;
   }
 
   type OrderRisksRecommendation = 'accept' | 'investigate' | 'cancel';


### PR DESCRIPTION
This is the continued/remaining effort to complete #447, and is also relevant to #288.

Resolves [this additional request](https://github.com/MONEI/Shopify-api-node/pull/447#issuecomment-809596052) by @lpinca:
> It should be done for all [supported endpoints](https://shopify.dev/tutorials/make-paginated-requests-to-rest-admin-api#supported-endpoints).