### PR TITLE
[ts] Corrected ICarrierItem type definition.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3189,7 +3189,9 @@ declare namespace Shopify {
     requires_shipping: boolean;
     taxable: boolean;
     fulfillment_service?: string;
-    properties?: ILineItemProperty;
+    properties?: {
+      [key: string]: string
+    };
     product_id: number;
     variant_id: number;
   }


### PR DESCRIPTION
Carrier callback requests type from Shopify was expecting line item properties to be in format of;
`{ name: string, value: string[] }` when the correct type is instead `{ [key :string]: string }`