### PR TITLE
Fix type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1391,12 +1391,12 @@ declare namespace Shopify {
     first_name: string;
     id: number;
     last_name: string;
-    latitude: string;
-    longitude: string;
+    latitude: number | null;
+    longitude: number | null;
     name: string;
     phone: string | null;
-    province: string;
-    province_code: string;
+    province: string | null;
+    province_code: string | null;
     zip: string;
   }
 


### PR DESCRIPTION
This pull request fixes the following type definitions:

~`province: string`~  ->  `province: string | null`
~`province_code: string`~  ->  `province_code: string | null`
~`latitude: string`~  -> `latitude: number | null`
~`longitude string`~  -> `longitude: number | null` 

Example of actual data sent by the Shopify API:

![types](https://user-images.githubusercontent.com/469519/115777205-836f3700-a3a4-11eb-9776-286be9e302ae.jpg)
_`province` can be `null`. `latitude`/`longitude` are `number`_

![types2](https://user-images.githubusercontent.com/469519/115788268-ebc51500-a3b2-11eb-834f-f1babb1fbbe2.jpg)
_`latitude`/`longitude` can be `null`_