### PR TITLE
Add params for productListing typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,7 +532,7 @@ This feature is only available on version 2.24.0 and above.
   - `list(productId[, params])`
   - `update(productId, id, params)`
 - productListing
-  - `count()`
+  - `count([params])`
   - `create(productId[, params])`
   - `delete(productId)`
   - `get(productId)`

--- a/index.d.ts
+++ b/index.d.ts
@@ -545,7 +545,7 @@ declare class Shopify {
     ) => Promise<Shopify.IProductImage>;
   };
   productListing: {
-    count: () => Promise<number>;
+    count: (params?: any) => Promise<number>;
     create: (
       productId: number,
       params: any


### PR DESCRIPTION
The productListing count method typings were missing the ability to pass in params.

The productListing count supports a number of params:
https://shopify.dev/docs/admin-api/rest/reference/products/product#count-2021-04