### PR TITLE
chore (ts): 2021-04 order api additions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2189,6 +2189,15 @@ declare namespace Shopify {
     confirmed: boolean;
     created_at: string;
     currency: string;
+    current_subtotal_price: string;
+    current_subtotal_price_set: IMoneySet;
+    current_total_discounts: string;
+    current_total_discounts_set: IMoneySet;
+    current_total_duties_set: null | IMoneySet;
+    current_total_price: string;
+    current_total_price_set: IMoneySet;
+    current_total_tax: string;
+    current_total_tax_set: IMoneySet;
     customer?: IOrderCustomer;
     customer_locale: string;
     discount_applications: IDiscountApplication[];


### PR DESCRIPTION
see https://shopify.dev/changelog/duties-are-now-available-on-the-storefront-api
note: `current_total_duties_set` is slightly different than the rest of the additions:  there's no `current_total_duties` and the value `null` when duties are not applicable