### PR TITLE
Added `tender_transactions/create`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3027,7 +3027,8 @@ declare namespace Shopify {
     | 'themes/create'
     | 'themes/delete'
     | 'themes/publish'
-    | 'themes/update';
+    | 'themes/update'
+    | 'tender_transactions/create';
 
   type WebhookFormat = 'json' | 'xml';
 


### PR DESCRIPTION
Added `tender_transactions/create` to the exported `WebhookTopic` type for closer adherence to Shopify's webhooks. 

https://shopify.dev/api/admin/rest/reference/events/webhook