### PR TITLE
bug: removed force_ssl according to new release 2021-07

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2711,7 +2711,6 @@ declare namespace Shopify {
     enabled_presentment_currencies: string[];
     email: string;
     finances: boolean;
-    force_ssl: boolean;
     google_apps_domain: string | null;
     google_apps_login_enabled: any | null;
     has_discounts: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2711,6 +2711,7 @@ declare namespace Shopify {
     enabled_presentment_currencies: string[];
     email: string;
     finances: boolean;
+    force_ssl?: boolean;
     google_apps_domain: string | null;
     google_apps_login_enabled: any | null;
     has_discounts: boolean;


### PR DESCRIPTION
release information https://shopify.dev/api/release-notes/2021-07
Topic: Deprecated field on Shop resource 
force_ssl field was removed from Shop resource