### PR TITLE
[ts] Fix IOrderShippingLine type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2178,6 +2178,7 @@ declare namespace Shopify {
   }
 
   interface IOrderShippingLine {
+    id: number;
     code: string;
     discounted_price: string;
     discounted_price_set: IMoneySet;


### PR DESCRIPTION
This pull request fixes missing `id` attribut on `IOrderShippingLine`.

Here is an example from Shopify response :

<img width="199" alt="screeshot" src="https://user-images.githubusercontent.com/12510911/152333054-d1e7ca84-f98d-4e7d-8e5a-f11fefbb55ca.png">


