### PR TITLE
feat: adding retry mechanism and unit test

### DIFF
--- a/mixins/utils.js
+++ b/mixins/utils.js
@@ -1,0 +1,104 @@
+const RetryableErrorCodes = new Set([
+  'ETIMEDOUT',
+  'ECONNRESET',
+  'EADDRINUSE',
+  'ECONNREFUSED',
+  'EPIPE',
+  'ENOTFOUND',
+  'ENETUNREACH',
+  'EAI_AGAIN'
+]);
+
+const responseFromError = (error) => {
+  if ('response' in error) {
+    const response = error.response;
+    if (response && 'body' in response) {
+      return response;
+    }
+  }
+  return error;
+};
+
+const isRetryableConnectionError = (error) => {
+  return (
+    typeof error === 'object' &&
+    'code' in error &&
+    RetryableErrorCodes.has(error.code)
+  );
+};
+
+/**
+ * This provides methods used by request to decide weather to retry call or not
+ *
+ * @mixin
+ */
+const utils = {
+  /**
+   * When retrying requests to Shopify, we introduce a random amount of jitter to the retry time to avoid all making requests in lockstep in a thundering herd.
+   * See https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/ for more information
+   * See https://github.com/tim-kos/node-retry#retryoperationoptions for an explanation of the math
+   */
+  addJitter: (baseRetrySeconds, attemptNumber) => {
+    return (
+      baseRetrySeconds + Math.min(Math.random() * Math.pow(2, attemptNumber), 6)
+    );
+  },
+
+  shouldRetryError: (error) => {
+    if (isRetryableConnectionError(error)) {
+      return 0;
+    }
+
+    const response = responseFromError(error);
+    if (!response) {
+      return null;
+    }
+
+    if (response.headers['retry-after']) {
+      const value = parseFloat(response.headers['retry-after']);
+      if (isNaN(value)) {
+        const when = new Date(value).valueOf();
+        return when - Date.now().valueOf();
+      } else if (isFinite(value)) {
+        return value;
+      } else {
+        return null;
+      }
+    }
+
+    if (
+      response.statusCode == 429 ||
+      (response.statusCode >= 500 && response.statusCode < 600)
+    ) {
+      // Arbitrary 2 seconds, in case we get a 429 without a Retry-After response header, or some 5xx response
+      return 2;
+    }
+
+    // detect graphql request throttling
+    if (response.body && typeof response.body === 'object') {
+      const body = response.body;
+
+      if (
+        body.errors &&
+        Array.isArray(body.errors) &&
+        typeof body.errors[0] === 'object' &&
+        body.errors[0].extensions?.code == 'THROTTLED'
+      ) {
+        const costData = body.extensions?.cost;
+        if (costData) {
+          return (
+            (costData.requestedQueryCost -
+              costData.throttleStatus.currentlyAvailable) /
+            costData.throttleStatus.restoreRate
+          );
+        } else {
+          return 2;
+        }
+      }
+    }
+
+    return null;
+  }
+};
+
+module.exports = utils;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "prettier": "^2.0.2"
   },
   "scripts": {
-    "test": "c8 --reporter=lcov --reporter=text mocha",
+    "test": "c8 --reporter=lcov --reporter=text mocha --timeout 15000",
     "watch": "mocha -w",
     "lint": "eslint --ignore-path .gitignore . && prettier --check --ignore-path .gitignore \"**/*.{json,md,ts,yaml,yml}\"",
     "prepare": "husky install"


### PR DESCRIPTION
Implemented following functionality:

- if the retry option is on, network errors are retried immediately
- if the retry option is on, 429 status codes are retried after the delay specified by the `Retry-After` header in the response
- if the retry option is on, GraphQL requests are retried after the cost is likely to be available in the rate limit again
- shopify-api-node's automatic rate limit avoidance (autoRetries) should still work if the retry option is on
- the library should not retry indefinitely, and give up after some number of retries, throwing an error to the caller
- all code needs to be tested