### PR TITLE
chore: use a more revealing assertion for leftover nock mocks

### DIFF
--- a/test/access-scope.test.js
+++ b/test/access-scope.test.js
@@ -9,7 +9,7 @@ describe('Shopify#accessScope', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of access scopes associated to the access token', () => {
     const output = fixtures.res.list;

--- a/test/api-permission.test.js
+++ b/test/api-permission.test.js
@@ -8,7 +8,7 @@ describe('Shopify#apiPermission', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('deletes an api permission', () => {
     scope.delete('/admin/api_permissions/current.json').reply(200);

--- a/test/application-charge.test.js
+++ b/test/application-charge.test.js
@@ -9,7 +9,7 @@ describe('Shopify#applicationCharge', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('create a new one-time application charge', () => {
     const input = fixtures.req.create;

--- a/test/application-credit.test.js
+++ b/test/application-credit.test.js
@@ -9,7 +9,7 @@ describe('Shopify#applicationCredit', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('creates an application credit', () => {
     const input = fixtures.req.create;

--- a/test/article.test.js
+++ b/test/article.test.js
@@ -9,7 +9,7 @@ describe('Shopify#article', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all articles from a certain blog (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/asset.test.js
+++ b/test/asset.test.js
@@ -10,7 +10,7 @@ describe('Shopify#asset', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all theme assets (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/balance.test.js
+++ b/test/balance.test.js
@@ -9,7 +9,7 @@ describe('Shopify#balance', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets the current balance', () => {
     const output = fixtures.res.list;

--- a/test/blog.test.js
+++ b/test/blog.test.js
@@ -9,7 +9,7 @@ describe('Shopify#blog', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all blogs (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/cancellation-request.test.js
+++ b/test/cancellation-request.test.js
@@ -9,7 +9,7 @@ describe('Shopify#cancellation-request', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('sends a cancellation request (1/2)', () => {
     const output = fixtures.res.create;

--- a/test/carrier-service.test.js
+++ b/test/carrier-service.test.js
@@ -9,7 +9,7 @@ describe('Shopify#carrierService', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('creates a carrier service', () => {
     const input = fixtures.req.create;

--- a/test/checkout.test.js
+++ b/test/checkout.test.js
@@ -9,7 +9,7 @@ describe('Shopify#checkout', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a count of all checkout (1/2)', () => {
     scope.get('/admin/checkouts/count.json').reply(200, { count: 5 });

--- a/test/collect.test.js
+++ b/test/collect.test.js
@@ -9,7 +9,7 @@ describe('Shopify#collect', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('adds a product to collection', () => {
     const input = fixtures.req.create;

--- a/test/collection-listing.test.js
+++ b/test/collection-listing.test.js
@@ -9,7 +9,7 @@ describe('Shopify#collectionListing', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets collection listings published to an application (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/collection.test.js
+++ b/test/collection.test.js
@@ -9,7 +9,7 @@ describe('Shopify#collection', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a collection by its ID (1/2)', () => {
     const output = fixtures.res.get;

--- a/test/comment.test.js
+++ b/test/comment.test.js
@@ -9,7 +9,7 @@ describe('Shopify#comment', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all comments (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/country.test.js
+++ b/test/country.test.js
@@ -9,7 +9,7 @@ describe('Shopify#country', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all countries (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/currency.test.js
+++ b/test/currency.test.js
@@ -9,7 +9,7 @@ describe('Shopify#currency', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of currencies enabled on a shop', () => {
     const output = fixtures.res.list;

--- a/test/custom-collection.test.js
+++ b/test/custom-collection.test.js
@@ -9,7 +9,7 @@ describe('Shopify#customCollection', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all custom collections (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/customer-address.test.js
+++ b/test/customer-address.test.js
@@ -10,7 +10,7 @@ describe('Shopify#customerAddress', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all addresses from a customer (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/customer-saved-search.test.js
+++ b/test/customer-saved-search.test.js
@@ -9,7 +9,7 @@ describe('Shopify#customerSavedSearch', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all customers saved searches (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/customer.test.js
+++ b/test/customer.test.js
@@ -10,7 +10,7 @@ describe('Shopify#customer', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all customers (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/deprecated-api-call.test.js
+++ b/test/deprecated-api-call.test.js
@@ -9,7 +9,7 @@ describe('Shopify#deprecatedApiCall', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of deprecated API calls', () => {
     const output = fixtures.res.list;

--- a/test/discount-code-creation-job.test.js
+++ b/test/discount-code-creation-job.test.js
@@ -9,7 +9,7 @@ describe('Shopify#discountCodeCreationJob', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('creates a new discount code creation job', () => {
     const input = fixtures.req.create;

--- a/test/discount-code.test.js
+++ b/test/discount-code.test.js
@@ -9,7 +9,7 @@ describe('Shopify#discountCode', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('creates a new discount code', () => {
     const input = fixtures.req.create;

--- a/test/dispute.test.js
+++ b/test/dispute.test.js
@@ -9,7 +9,7 @@ describe('Shopify#dispute', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list disputes (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/draft-order.test.js
+++ b/test/draft-order.test.js
@@ -9,7 +9,7 @@ describe('Shopify#draftOrder', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of draft orders (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/event.test.js
+++ b/test/event.test.js
@@ -9,7 +9,7 @@ describe('Shopify#event', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of events (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/fulfillment-event.test.js
+++ b/test/fulfillment-event.test.js
@@ -13,7 +13,7 @@ describe('Shopify#fulfillmentEvent', () => {
   const shopify = common.shopify;
   const shopName = common.shopName;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all fulfillments events for a fulfillment (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/fulfillment-order.test.js
+++ b/test/fulfillment-order.test.js
@@ -9,7 +9,7 @@ describe('Shopify#fulfillmentOrder', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of fulfillment orders on a shop for a specific app', () => {
     const output = fixtures.res.list;

--- a/test/fulfillment-request.test.js
+++ b/test/fulfillment-request.test.js
@@ -9,7 +9,7 @@ describe('Shopify#fulfillment-request', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('sends a fulfillment request', () => {
     const input = fixtures.req.create;

--- a/test/fulfillment-service.test.js
+++ b/test/fulfillment-service.test.js
@@ -9,7 +9,7 @@ describe('Shopify#fulfillmentService', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all fulfillment services', () => {
     const output = fixtures.res.list;

--- a/test/fulfillment.test.js
+++ b/test/fulfillment.test.js
@@ -13,7 +13,7 @@ describe('Shopify#fulfillment', () => {
   const shopify = common.shopify;
   const shopName = common.shopName;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all fulfillments for an order (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/gift-card-adjustment.test.js
+++ b/test/gift-card-adjustment.test.js
@@ -9,7 +9,7 @@ describe('Shopify#giftCardAdjustment', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all gift card adjustments', () => {
     const output = fixtures.res.list;

--- a/test/gift-card.test.js
+++ b/test/gift-card.test.js
@@ -9,7 +9,7 @@ describe('Shopify#giftCard', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all gift cards (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/inventory-item.test.js
+++ b/test/inventory-item.test.js
@@ -10,7 +10,7 @@ describe('Shopify#inventoryItem', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of inventory items', () => {
     const query = { ids: '808950810,39072856,457924702' };

--- a/test/inventory-level.test.js
+++ b/test/inventory-level.test.js
@@ -10,7 +10,7 @@ describe('Shopify#inventoryLevel', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of inventory levels', () => {
     const query = { inventory_item_ids: 808950810 };

--- a/test/location.test.js
+++ b/test/location.test.js
@@ -9,7 +9,7 @@ describe('Shopify#location', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all locations', () => {
     const output = fixtures.res.list;

--- a/test/marketing-event.test.js
+++ b/test/marketing-event.test.js
@@ -9,7 +9,7 @@ describe('Shopify#marketingEvent', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all marketing events (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/metafield.test.js
+++ b/test/metafield.test.js
@@ -9,7 +9,7 @@ describe('Shopify#metafield', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of metafields that belong to a store (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/order-risk.test.js
+++ b/test/order-risk.test.js
@@ -9,7 +9,7 @@ describe('Shopify#orderRisk', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('create a new order risk for an order', () => {
     const input = fixtures.req.create;

--- a/test/order.test.js
+++ b/test/order.test.js
@@ -9,7 +9,7 @@ describe('Shopify#order', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all orders (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/page.test.js
+++ b/test/page.test.js
@@ -9,7 +9,7 @@ describe('Shopify#page', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all pages (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/payment.test.js
+++ b/test/payment.test.js
@@ -9,7 +9,7 @@ describe('Shopify#payment', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of payments on a particular checkout', () => {
     const output = fixtures.res.list;

--- a/test/payout.test.js
+++ b/test/payout.test.js
@@ -13,7 +13,7 @@ describe('Shopify#payout', () => {
   const shopify = common.shopify;
   const shopName = common.shopName;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list payouts (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/policy.test.js
+++ b/test/policy.test.js
@@ -9,7 +9,7 @@ describe('Shopify#policy', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all policies (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/price-rule.test.js
+++ b/test/price-rule.test.js
@@ -9,7 +9,7 @@ describe('Shopify#priceRule', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('creates a new price rule', () => {
     const input = fixtures.req.create;

--- a/test/product-image.test.js
+++ b/test/product-image.test.js
@@ -9,7 +9,7 @@ describe('Shopify#productImage', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all product images for a product (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/product-listing.test.js
+++ b/test/product-listing.test.js
@@ -12,8 +12,8 @@ describe('Shopify#productListing', () => {
   const presentmentApiScope = common.presentmentApiScope;
 
   afterEach(() => {
-    expect(presentmentApiScope.isDone()).to.be.true;
-    expect(standardScope.isDone()).to.be.true;
+    expect(presentmentApiScope.pendingMocks()).to.deep.equal([]);
+    expect(standardScope.pendingMocks()).to.deep.equal([]);
   });
 
   it('gets product listings published to an application (1/4)', () => {

--- a/test/product-resource-feedback.test.js
+++ b/test/product-resource-feedback.test.js
@@ -9,7 +9,7 @@ describe('Shopify#productResourceFeedback', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('creates a resource feedback', () => {
     const input = fixtures.req.create;

--- a/test/product-variant.test.js
+++ b/test/product-variant.test.js
@@ -12,8 +12,8 @@ describe('Shopify#productVariant', () => {
   const presentmentApiScope = common.presentmentApiScope;
 
   afterEach(() => {
-    expect(presentmentApiScope.isDone()).to.be.true;
-    expect(standardScope.isDone()).to.be.true;
+    expect(presentmentApiScope.pendingMocks()).to.deep.equal([]);
+    expect(standardScope.pendingMocks()).to.deep.equal([]);
   });
 
   it('gets a list of all product variants for a product (1/4)', () => {

--- a/test/product.test.js
+++ b/test/product.test.js
@@ -12,8 +12,8 @@ describe('Shopify#product', () => {
   const presentmentApiScope = common.presentmentApiScope;
 
   afterEach(() => {
-    expect(presentmentApiScope.isDone()).to.be.true;
-    expect(standardScope.isDone()).to.be.true;
+    expect(presentmentApiScope.pendingMocks()).to.deep.equal([]);
+    expect(standardScope.pendingMocks()).to.deep.equal([]);
   });
 
   it('gets a list of all products (1/4)', () => {

--- a/test/province.test.js
+++ b/test/province.test.js
@@ -9,7 +9,7 @@ describe('Shopify#province', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all provinces for a country (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/recurring-application-charge.test.js
+++ b/test/recurring-application-charge.test.js
@@ -9,7 +9,7 @@ describe('Shopify#recurringApplicationCharge', () => {
   const resource = common.shopify.recurringApplicationCharge;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('creates a recurring application charge', () => {
     const input = fixtures.req.create;

--- a/test/redirect.test.js
+++ b/test/redirect.test.js
@@ -9,7 +9,7 @@ describe('Shopify#redirect', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all redirects (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/refund.test.js
+++ b/test/refund.test.js
@@ -9,7 +9,7 @@ describe('Shopify#refund', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of refunds for an order (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/report.test.js
+++ b/test/report.test.js
@@ -9,7 +9,7 @@ describe('Shopify#report', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all reports (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/resource-feedback.test.js
+++ b/test/resource-feedback.test.js
@@ -9,7 +9,7 @@ describe('Shopify#resourceFeedback', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('creates a resource feedback', () => {
     const input = fixtures.req.create;

--- a/test/script-tag.test.js
+++ b/test/script-tag.test.js
@@ -9,7 +9,7 @@ describe('Shopify#scriptTag', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all script tags (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/shipping-zone.test.js
+++ b/test/shipping-zone.test.js
@@ -9,7 +9,7 @@ describe('Shopify#shippingZone', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all shipping zones (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/shop.test.js
+++ b/test/shop.test.js
@@ -13,7 +13,7 @@ describe('Shopify#shop', () => {
   const shopify = common.shopify;
   const shopName = common.shopName;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets the configuration of the shop (1/2)', () => {
     const output = fixtures.res.get;

--- a/test/shopify.test.js
+++ b/test/shopify.test.js
@@ -123,7 +123,7 @@ describe('Shopify', () => {
     const url = { pathname: '/test', ...shopify.baseUrl };
     const scope = common.scope;
 
-    afterEach(() => expect(nock.isDone()).to.be.true);
+    afterEach(() => expect(nock.pendingMocks()).to.deep.equal([]));
 
     it('returns a RequestError when the request fails', () => {
       const message = 'Something wrong happened';
@@ -539,7 +539,7 @@ describe('Shopify', () => {
       }
     });
 
-    afterEach(() => expect(nock.isDone()).to.be.true);
+    afterEach(() => expect(nock.pendingMocks()).to.deep.equal([]));
 
     it('returns a RequestError when the request fails', () => {
       const message = 'Something wrong happened';

--- a/test/smart-collection.test.js
+++ b/test/smart-collection.test.js
@@ -10,7 +10,7 @@ describe('Shopify#smartCollection', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all smart collections (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/storefront-access-token.test.js
+++ b/test/storefront-access-token.test.js
@@ -9,7 +9,7 @@ describe('Shopify#storefrontAccessToken', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('creates a storefront access token', () => {
     const input = fixtures.req.create;

--- a/test/tender-transaction.test.js
+++ b/test/tender-transaction.test.js
@@ -9,7 +9,7 @@ describe('Shopify#tenderTransaction', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of tender transactions (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/theme.test.js
+++ b/test/theme.test.js
@@ -9,7 +9,7 @@ describe('Shopify#theme', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all themes (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -9,7 +9,7 @@ describe('Shopify#transaction', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all transactions for an order (1/2)', () => {
     const output = fixtures.res.list;

--- a/test/usage-charge.test.js
+++ b/test/usage-charge.test.js
@@ -10,7 +10,7 @@ describe('Shopify#usageCharge', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('creates a new usage charge', () => {
     const input = fixtures.req.create;

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -9,7 +9,7 @@ describe('Shopify#user', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all users', () => {
     const output = fixtures.res.list;

--- a/test/webhook.test.js
+++ b/test/webhook.test.js
@@ -10,7 +10,7 @@ describe('Shopify#webhook', () => {
   const shopify = common.shopify;
   const scope = common.scope;
 
-  afterEach(() => expect(scope.isDone()).to.be.true);
+  afterEach(() => expect(scope.pendingMocks()).to.deep.equal([]));
 
   it('gets a list of all webhooks (1/2)', () => {
     const output = fixtures.res.list;


### PR DESCRIPTION
There's a wise afterEach assertion that runs after every test to ensure that no nock request mocks are left over. If you're working on tests which use nock, it can be annoying though, because you need to figure out which mock is not being hit to fix the test. Instead of just asserting that there are no mocks, we can use an assertion of the list of mocks to show the developer what mocks are still hanging around with mocha's nice diff.