### PR TITLE
Ensure that body extensions aren't inspected unless the body is an array

### DIFF
--- a/index.js
+++ b/index.js
@@ -380,6 +380,7 @@ function maybeRetryMS(error) {
 
     if (
       body.errors &&
+      Array.isArray(body.errors) &&
       body.errors[0].extensions &&
       body.errors[0].extensions.code == 'THROTTLED'
     ) {

--- a/test/shopify.test.js
+++ b/test/shopify.test.js
@@ -584,6 +584,47 @@ describe('Shopify', () => {
       });
     });
 
+    it("doesn't retry 422 errors that return an error string", () => {
+      scope.put('/admin/products/10.json').reply(422, {
+        error: 'the product was invalid'
+      });
+
+      return shopifyWithRetries.product.update(10).catch((err) => {
+        expect(err).to.be.an.instanceof(got.HTTPError);
+        expect(err.message).to.equal(
+          'Response code 422 (Unprocessable Entity)'
+        );
+      });
+    });
+
+    it("doesn't retry 422 errors that return an errors array", () => {
+      scope.put('/admin/products/10.json').reply(422, {
+        errors: ['the product was invalid']
+      });
+
+      return shopifyWithRetries.product.update(10).catch((err) => {
+        expect(err).to.be.an.instanceof(got.HTTPError);
+        expect(err.message).to.equal(
+          'Response code 422 (Unprocessable Entity)'
+        );
+      });
+    });
+
+    it("doesn't retry 422 errors that return an errors object", () => {
+      scope.put('/admin/products/10.json').reply(422, {
+        errors: {
+          title: 'is required'
+        }
+      });
+
+      return shopifyWithRetries.product.update(10).catch((err) => {
+        expect(err).to.be.an.instanceof(got.HTTPError);
+        expect(err.message).to.equal(
+          'Response code 422 (Unprocessable Entity)'
+        );
+      });
+    });
+
     it('retries 500 errors from shopify', () => {
       scope.get('/admin/shop.json').reply(500, {
         error: 'something went wrong'


### PR DESCRIPTION
Fixes #547. During the code review of the retries PR, we ended up unifying the REST and GraphQL error handling logic, and also dropping the defensive bits that ensured the format of the errors object was checked before doing properties access. This restores the defensive checks since this code now needs to touch errors from the REST API which come in all sorts of shapes.