### PR TITLE
Fix retryable status codes not respecting max retries option

### DIFF
--- a/test/shopify.test.js
+++ b/test/shopify.test.js
@@ -573,6 +573,22 @@ describe('Shopify', () => {
       });
     });
 
+    it('honors the maxRetries option', () => {
+      let attempts = 0;
+      scope
+        .get('/admin/shop.json')
+        .times(4)
+        .reply(429, () => {
+          attempts++;
+          return 'too many requests';
+        });
+
+      return shopifyWithRetries.shop.get().catch((result) => {
+        expect(result.response.statusCode).equal(429);
+        expect(attempts).equal(4);
+      });
+    }).timeout(8000);
+
     it("doesn't retry 404 errors", () => {
       scope.get('/admin/products/10.json').reply(404, {
         error: 'not found'


### PR DESCRIPTION
While writing some tests for our own usage of `shopif-api-node`, I noticed that retries on `retryableStatusCodes` were not respecting `got`'s retry limit. According to `got`'s documentation:

> This function is responsible for the entire retry mechanism, including the limit property. To support this, you need to check if computedValue is different than 0.

Let's rely on their recommended check to ensure we aren't past the retry limit and ensure that retries are not indefinite if a `maxRetries` is set. Lastly, since we haven't explicitly included status code `200` as retryable we have to handle "Throttled" requests before attempting to check `computedValue`.