### PR TITLE
Update FulfillmentEventStatus

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1780,7 +1780,7 @@ declare namespace Shopify {
     variant_inventory_management: string;
   }
 
-type FulfillmentEventStatus =
+  type FulfillmentEventStatus =
     | 'attempted_delivery'
     | 'confirmed'
     | 'delivered'

--- a/index.d.ts
+++ b/index.d.ts
@@ -1780,12 +1780,17 @@ declare namespace Shopify {
     variant_inventory_management: string;
   }
 
-  type FulfillmentEventStatus =
+type FulfillmentEventStatus =
+    | 'attempted_delivery'
     | 'confirmed'
     | 'delivered'
     | 'failure'
     | 'in_transit'
-    | 'out_for_delivery';
+    | 'label_printed'
+    | 'label_purchased'
+    | 'out_for_delivery'
+    | 'picked_up'
+    | 'ready_for_pickup';
 
   interface IFulfillmentEvent {
     address1: string | null;


### PR DESCRIPTION
Additional values for `FulfillmentEventStatus` based on https://shopify.dev/api/admin-rest/2022-07/resources/fulfillmentevent

> ###  `status`
> The status of the fulfillment event.Valid values:
> - `label_printed`: A label for the shipment was purchased and printed.
> - `label_purchased`: A label for the shipment was purchased, but not printed.
> - `attempted_delivery`: Delivery of the shipment was attempted, but unable to be completed.
> - `ready_for_pickup`: The shipment is ready for pickup at a shipping depot.
> - `picked_up`: The fulfillment was successfully picked up.
> - `confirmed`: The carrier is aware of the shipment, but hasn't received it yet.
> - `in_transit`: The shipment is being transported between shipping facilities on the way to its destination.
> - `out_for_delivery`: The shipment is being delivered to its final destination.
> - `delivered`: The shipment was successfully delivered.
> - `failure`: Something went wrong when pulling tracking information for the shipment, such as the tracking number was invalid or the shipment was canceled.

