### PR TITLE
Add support for passing request lifecycle hooks down to got

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ Creates a new `Shopify` instance.
   for requests to the REST API, and the throttled cost data for requests to the
   GraphQL API, and retry the request after that time has elapsed. Mutually
   exclusive with the `autoLimit` option.
+- `hooks` - Optional - A list of `got`
+  [request hooks](https://github.com/sindresorhus/got/tree/v11#hooks) to attach
+  to all outgoing requests, like `beforeRetry`, `afterResponse`, etc. Hooks
+  should be provided in the same format that Got expects them and will receive
+  the same arguments Got passes unchanged.
 
 #### Return value
 
@@ -716,6 +721,34 @@ shopify
   .then((customers) => console.log(customers))
   .catch((err) => console.error(err));
 ```
+
+## Hooks
+
+`shopify-api-node` supports being passed hooks which are called by `got` (the
+underlying request library) during the request lifecycle.
+
+For example, we can log every error that is encountered when using the
+`maxRetries` option:
+
+```js
+const shopify = new Shopify({
+  shopName: 'your-shop-name',
+  accessToken: 'your-oauth-token'
+  // enable automatic retries for this client
+  maxRetries: 3,
+  // pass the `beforeRetry` hook down to Got
+  hooks: {
+    beforeRetry: [
+      (options, error, retryCount) => {
+        console.warn("Error encountered making Shopify request, retrying", error);
+			}
+    ]
+  }
+});
+```
+
+For more information on the available `got` hooks, see the
+[`got` v11 hooks documentation](https://github.com/sindresorhus/got/tree/v11#hooks).
 
 ## Become a master of the Shopify ecosystem by:
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 // Type definitions for shopify-api-node
 // Project: shopify-api-node
 // Definitions by: Rich Buggy <rich@buggy.id.au>
+import { Got } from 'got';
 
 /*~ This is the module template file for class modules.
  *~ You should rename it to index.d.ts and place it in a folder with the same name as the module.
@@ -783,6 +784,7 @@ declare namespace Shopify {
     presentmentPrices?: boolean;
     shopName: string;
     timeout?: number;
+    hooks?: Got.Hooks;
   }
 
   export interface IPrivateShopifyConfig {
@@ -794,6 +796,7 @@ declare namespace Shopify {
     presentmentPrices?: boolean;
     shopName: string;
     timeout?: number;
+    hooks?: Got.Hooks;
   }
 
   export interface ICallLimits {

--- a/index.js
+++ b/index.js
@@ -168,11 +168,13 @@ Shopify.prototype.request = function request(uri, method, key, data, headers) {
         : 0,
     method,
     hooks: {
+      ...this.options.hooks,
       afterResponse: [
         (res) => {
           this.updateLimits(res.headers['x-shopify-shop-api-call-limit']);
           return res;
-        }
+        },
+        ...((this.options.hooks && this.options.hooks.afterResponse) || [])
       ]
     }
   };
@@ -286,6 +288,7 @@ Shopify.prototype.graphql = function graphql(data, variables) {
           }
         : 0,
     hooks: {
+      ...this.options.hooks,
       afterResponse: [
         (res) => {
           if (res.body) {
@@ -300,9 +303,13 @@ Shopify.prototype.graphql = function graphql(data, variables) {
           }
 
           return res;
-        }
+        },
+        ...((this.options.hooks && this.options.hooks.afterResponse) || [])
       ],
-      beforeError: [decorateError]
+      beforeError: [
+        decorateError,
+        ...((this.options.hooks && this.options.hooks.beforeError) || [])
+      ]
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "lint-staged": "^13.0.0",
     "mocha": "^8.0.1",
     "nock": "^13.0.1",
-    "prettier": "^2.0.2"
+    "prettier": "^2.0.2",
+    "sinon": "^15.0.0"
   },
   "scripts": {
     "test": "c8 --reporter=lcov --reporter=text mocha",

--- a/test/shopify.test.js
+++ b/test/shopify.test.js
@@ -7,6 +7,7 @@ describe('Shopify', () => {
   const nock = require('nock');
   const got = require('got');
   const qs = require('qs');
+  const sinon = require('sinon');
 
   const Blog = require('../resources/blog');
   const common = require('./common');
@@ -702,6 +703,73 @@ describe('Shopify', () => {
         expect(result.name).equal('My Cool Test Shop');
       });
     }).timeout(10000);
+
+    it('calls hooks passed as options when accessing resources', () => {
+      const beforeRequest = sinon.fake();
+      const afterResponse = sinon.fake((x) => x);
+
+      const shopify = new Shopify({
+        accessToken,
+        shopName,
+        hooks: {
+          beforeRequest: [beforeRequest],
+          afterResponse: [afterResponse]
+        }
+      });
+
+      addWorkingRESTRequestMock(scope);
+
+      return shopify.shop.get().then(() => {
+        expect(beforeRequest.called).to.be.true;
+        expect(afterResponse.called).to.be.true;
+      });
+    });
+
+    it('calls hooks passed as options when making raw requests', () => {
+      const beforeRequest = sinon.fake();
+      const afterResponse = sinon.fake((x) => x);
+
+      const shopify = new Shopify({
+        accessToken,
+        shopName,
+        hooks: {
+          beforeRequest: [beforeRequest],
+          afterResponse: [afterResponse]
+        }
+      });
+
+      scope.get('/test').reply(200, {});
+
+      return shopify.request(url, 'GET').then(() => {
+        expect(beforeRequest.called).to.be.true;
+        expect(afterResponse.called).to.be.true;
+      });
+    });
+
+    it('calls the beforeRetry hook for retried requests', () => {
+      const beforeRetry = sinon.fake();
+
+      const shopify = new Shopify({
+        accessToken,
+        shopName,
+        maxRetries: 3,
+        hooks: {
+          beforeRetry: [beforeRetry]
+        }
+      });
+
+      scope.get('/admin/shop.json').replyWithError({
+        message: 'the network is broken',
+        code: 'ECONNRESET'
+      });
+
+      addWorkingRESTRequestMock(scope);
+
+      return shopify.shop.get().then((result) => {
+        expect(beforeRetry.called).to.be.true;
+        expect(result.name).equal('My Cool Test Shop');
+      });
+    });
   });
 
   describe('Shopify#graphql', () => {
@@ -1127,5 +1195,73 @@ describe('Shopify', () => {
           expect(result.shop.name).equal('My Cool Test Shop');
         });
     }).timeout(3000);
+
+    it('calls hooks passed as options when making graphql requests', () => {
+      const beforeRequest = sinon.fake();
+      const afterResponse = sinon.fake((x) => x);
+
+      const shopify = new Shopify({
+        accessToken,
+        shopName,
+        hooks: {
+          beforeRequest: [beforeRequest],
+          afterResponse: [afterResponse]
+        }
+      });
+
+      scope.post('/admin/api/graphql.json').reply(200, {
+        data: { foo: 'bar' }
+      });
+
+      return shopify.graphql('query').then(() => {
+        expect(beforeRequest.called).to.be.true;
+        expect(afterResponse.called).to.be.true;
+      });
+    });
+
+    it('calls the beforeRetry hook for retried requests', () => {
+      const beforeRetry = sinon.fake();
+
+      const shopify = new Shopify({
+        accessToken,
+        shopName,
+        maxRetries: 3,
+        hooks: {
+          beforeRetry: [beforeRetry]
+        }
+      });
+
+      scope.post('/admin/api/graphql.json').replyWithError({
+        message: 'the network is broken',
+        code: 'ECONNRESET'
+      });
+
+      addWorkingGraphQLRequestMock(scope);
+
+      return shopify.graphql('query { shop { id name } }').then(() => {
+        expect(beforeRetry.called).to.be.true;
+      });
+    });
+
+    it('calls the beforeError hook for errors', () => {
+      const beforeError = sinon.fake((x) => x);
+
+      const shopify = new Shopify({
+        accessToken,
+        shopName,
+        hooks: {
+          beforeError: [beforeError]
+        }
+      });
+
+      scope.post('/admin/api/graphql.json').replyWithError({
+        message: 'the network is broken',
+        code: 'ECONNRESET'
+      });
+
+      return shopify.graphql('query { shop { id name } }').catch(() => {
+        expect(beforeError.called).to.be.true;
+      });
+    });
   });
 });


### PR DESCRIPTION
`got` has rich support for request lifecycle hooks that allow userland code to understand what is happening within got and to modify it's behaviour. `shopify-api-node` uses got hooks for some retry implementation, but I think that users of `shopify-api-node` like me also want to know about whats happening during retries and errors. 

For this reason, I think that `shopify-api-node` should accept request hooks too! This allows users of shopify-api-node to log each retry, or decorate errors with extra context, or add in tracing and other observability hooks to get great visibility on what the library is doing. See a good example of this in the readme.

There's not much maintenance burden for this library if we just passthrough to got (like we do with the request options itself).