### PR TITLE
graphql: capture first errors message for 2xx error responses only

### DIFF
--- a/index.js
+++ b/index.js
@@ -295,7 +295,7 @@ Shopify.prototype.graphql = function graphql(data, variables) {
 
             if (res.body.errors) {
               // Make Got consider this response errored and retry if needed.
-              throw new Error(res.body.errors[0].message);
+              throw new Error(Array.isArray(res.body.errors) ? res.body.errors[0].message : res.body.errors);
             }
           }
 

--- a/index.js
+++ b/index.js
@@ -293,7 +293,7 @@ Shopify.prototype.graphql = function graphql(data, variables) {
               this.updateGraphqlLimits(res.body.extensions.cost);
             }
 
-            if (res.body.errors && Array.isArray(res.body.errors)) {
+            if (Array.isArray(res.body.errors)) {
               // Make Got consider this response errored and retry if needed.
               throw new Error(res.body.errors[0].message);
             }
@@ -320,11 +320,7 @@ resources.registerAll(Shopify);
  * @private
  */
 function decorateError(error) {
-  if (
-    error.response &&
-    error.response.body.errors &&
-    Array.isArray(error.response.body.errors)
-  ) {
+  if (error.response && Array.isArray(error.response.body.errors)) {
     const first = error.response.body.errors[0];
 
     error.locations = first.locations;

--- a/index.js
+++ b/index.js
@@ -295,11 +295,7 @@ Shopify.prototype.graphql = function graphql(data, variables) {
 
             if (res.body.errors) {
               // Make Got consider this response errored and retry if needed.
-              throw new Error(
-                Array.isArray(res.body.errors)
-                  ? res.body.errors[0].message
-                  : res.body.errors
-              );
+              throw new Error(res.body.errors[0].message);
             }
           }
 

--- a/index.js
+++ b/index.js
@@ -293,7 +293,7 @@ Shopify.prototype.graphql = function graphql(data, variables) {
               this.updateGraphqlLimits(res.body.extensions.cost);
             }
 
-            if (res.body.errors) {
+            if (res.body.errors && Array.isArray(res.body.errors)) {
               // Make Got consider this response errored and retry if needed.
               throw new Error(res.body.errors[0].message);
             }
@@ -320,7 +320,11 @@ resources.registerAll(Shopify);
  * @private
  */
 function decorateError(error) {
-  if (error.response && error.response.body.errors) {
+  if (
+    error.response &&
+    error.response.body.errors &&
+    Array.isArray(error.response.body.errors)
+  ) {
     const first = error.response.body.errors[0];
 
     error.locations = first.locations;

--- a/index.js
+++ b/index.js
@@ -295,9 +295,11 @@ Shopify.prototype.graphql = function graphql(data, variables) {
 
             if (res.body.errors) {
               // Make Got consider this response errored and retry if needed.
-              throw new Error(Array.isArray(res.body.errors)
-                ? res.body.errors[0].message
-                : res.body.errors);
+              throw new Error(
+                Array.isArray(res.body.errors)
+                  ? res.body.errors[0].message
+                  : res.body.errors
+              );
             }
           }
 

--- a/index.js
+++ b/index.js
@@ -295,7 +295,9 @@ Shopify.prototype.graphql = function graphql(data, variables) {
 
             if (res.body.errors) {
               // Make Got consider this response errored and retry if needed.
-              throw new Error(Array.isArray(res.body.errors) ? res.body.errors[0].message : res.body.errors);
+              throw new Error(Array.isArray(res.body.errors)
+                ? res.body.errors[0].message
+                : res.body.errors);
             }
           }
 


### PR DESCRIPTION
Error improvement for GraphQL API error responses per docs: https://shopify.dev/api/admin-graphql#status_and_error_codes

**Issue**

HTTP error responses return `{ errors: '...' }` instead of `{ errors: [...] }`

This results in errors with `message: undefined` for some errors.

Example responses:
```
HTTP/1.1 402 Payment Required
{ "errors": "This shop's plan does not have access to this feature" }
```
```
HTTP/1.1 404 Not Found
{ "errors": "Not Found" }
```

**Change**

~Fallback to passing through `body.errors` for non array values. Avoid branching on http status codes as it's not entirely clear what segments need handling (eg. 3xx).~

Ensure non-2xx errors _with_ a `errors` property that isn't an array are not intercepted and pass through as response errors.

