### PR TITLE
[ts] Fix IOrderDiscountCode.amount type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2196,7 +2196,7 @@ declare namespace Shopify {
     | 'offsite';
 
   interface IOrderDiscountCode {
-    amount: number;
+    amount: string;
     code: string;
     type: OrderDiscountCodeType;
   }


### PR DESCRIPTION
Changes `amount` from `number` to `string` per API docs (sample response, types undocumented in resource listing).

> ```json
> 155    "discount_codes": [
> 156      {
> 157        "code": "SPRING30",
> 158        "amount": "30.00",
> 159        "type": "fixed_amount"
> 160      }
> 161    ],
> ```
> Order resource example response (https://shopify.dev/api/admin-rest/2022-04/resources/order#resource-object)

FYI `line_items.discount_allocations` ([`ILineItemDiscountAllocation`](https://github.com/summersk/Shopify-api-node/blob/b3c1f6aefec185b8bf974535a8b784d5ee9181ac/index.d.ts#L2022)) has `amount: string` already.
