### PR TITLE
Fix #566 and introduce light types tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       - run: npm run lint
         if: matrix.node == 18
       - run: npm test
+      - run: npm run test:types
       - uses: coverallsapp/github-action@1.1.3
         if: matrix.node == 18
         with:

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 // Type definitions for shopify-api-node
 // Project: shopify-api-node
 // Definitions by: Rich Buggy <rich@buggy.id.au>
-import { Got } from 'got';
+import { Hooks } from 'got';
 
 /*~ This is the module template file for class modules.
  *~ You should rename it to index.d.ts and place it in a folder with the same name as the module.
@@ -788,7 +788,7 @@ declare namespace Shopify {
     presentmentPrices?: boolean;
     shopName: string;
     timeout?: number;
-    hooks?: Got.Hooks;
+    hooks?: Hooks;
   }
 
   export interface IPrivateShopifyConfig {
@@ -800,7 +800,7 @@ declare namespace Shopify {
     presentmentPrices?: boolean;
     shopName: string;
     timeout?: number;
-    hooks?: Got.Hooks;
+    hooks?: Hooks;
   }
 
   export interface ICallLimits {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,43 @@
+import { expectType } from 'tsd';
+import Shopify from '.';
+
+// can be constructed with public access token
+new Shopify({
+  shopName: 'my-shopify-store.myshopify.com',
+  accessToken: '111'
+});
+
+// can be constructed with public access token and version
+const client = new Shopify({
+  shopName: 'my-shopify-store.myshopify.com',
+  accessToken: '111',
+  apiVersion: '2020-01'
+});
+
+// can be constructed with got hooks
+new Shopify({
+  shopName: 'my-shopify-store.myshopify.com',
+  accessToken: '111',
+  hooks: {
+    beforeRequest: [
+      (options) => {
+        options.headers['X-Test'] = 'test';
+      }
+    ]
+  }
+});
+
+expectType<number>(client.callLimits.remaining);
+expectType<number>(client.callLimits.current);
+expectType<number>(client.callLimits.max);
+
+const shop = await client.shop.get();
+expectType<number>(shop.id);
+expectType<string>(shop.myshopify_domain);
+
+const product = await client.product.get(10);
+expectType<number>(product.id);
+expectType<string>(product.title);
+
+const result = await client.graphql(`query { shop { id myshopify_domain } }`);
+expectType<any>(result);

--- a/package.json
+++ b/package.json
@@ -32,10 +32,12 @@
     "lint-staged": "^13.0.0",
     "mocha": "^8.0.1",
     "nock": "^13.0.1",
-    "prettier": "^2.0.2"
+    "prettier": "^2.0.2",
+    "tsd": "^0.25.0"
   },
   "scripts": {
     "test": "c8 --reporter=lcov --reporter=text mocha",
+    "test:types": "tsd",
     "watch": "mocha -w",
     "lint": "eslint --ignore-path .gitignore . && prettier --check --ignore-path .gitignore \"**/*.{json,md,ts,yaml,yml}\"",
     "prepare": "husky install"


### PR DESCRIPTION
This fixes a type error introduced in https://github.com/MONEI/Shopify-api-node/commit/eeda19880b634d5080e3ab2cc5b77513276c8dbe and reported in https://github.com/MONEI/Shopify-api-node/issues/566 . I made this mistake by copying code suitable for got 12 into a codebase using got 11 -- my apologies! To avoid breakages like this, I think it'd be good to have a lightweight typescript test suite that verifies the types file works as expected. tsd is a great tool for this so I added it here as well.

