### PR TITLE
delivery_method can be null

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1924,7 +1924,7 @@ declare namespace Shopify {
     supported_actions: FulfillmentOrderSupportedAction[];
     fulfillment_holds: IFulfillmentOrderFulfillmentHolds[];
     international_duties: IFulfillmentOrderInternationalDuties;
-    delivery_method: IFulfillmentOrderDeliveryMethod;
+    delivery_method: IFulfillmentOrderDeliveryMethod | null;
   }
 
   interface ILocationForMoveLocation {


### PR DESCRIPTION
Docs does not say it, but after playing around with the fulfillment orders API, there were some instances where it came back as null.