### PR TITLE
Adds missing `FulfillmentOrderStatus`es

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1860,7 +1860,9 @@ declare namespace Shopify {
     | 'closed'
     | 'in_progress'
     | 'incomplete'
-    | 'open';
+    | 'open'
+    | 'on_hold'
+    | 'scheduled';
 
   type FulfillmentOrderSupportedAction =
     | 'cancel_fulfillment_order'


### PR DESCRIPTION
The `on_hold` and `scheduled` statuses were missing. [See documentation](https://shopify.dev/docs/api/admin-rest/2023-01/resources/fulfillmentorder#resource-object)