### PR TITLE
Fix issue with metafields

### DIFF
--- a/resources/metafield.js
+++ b/resources/metafield.js
@@ -2,7 +2,7 @@
 
 const assign = require('lodash/assign');
 
-const base = require('../mixins/base');
+const baseChild = require('../mixins/base-child');
 
 /**
  * Creates a Metafield instance.
@@ -18,6 +18,6 @@ function Metafield(shopify) {
   this.key = 'metafield';
 }
 
-assign(Metafield.prototype, base);
+assign(Metafield.prototype, baseChild);
 
 module.exports = Metafield;


### PR DESCRIPTION
Metafields are child resources, so must use the `base-child` mixin.

For example, the metafields list function only returns the Shop metafields, regardless of the `owner_resource` and `owner_id` that we provide.