### PR TITLE
Updating broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ Creates a new `Shopify` instance.
   GraphQL API, and retry the request after that time has elapsed. Mutually
   exclusive with the `autoLimit` option.
 - `hooks` - Optional - A list of `got`
-  [request hooks](https://github.com/sindresorhus/got/tree/v11.8.6#hooks) to attach
-  to all outgoing requests, like `beforeRetry`, `afterResponse`, etc. Hooks
-  should be provided in the same format that Got expects them and will receive
-  the same arguments Got passes unchanged.
+  [request hooks](https://github.com/sindresorhus/got/tree/v11.8.6#hooks) to
+  attach to all outgoing requests, like `beforeRetry`, `afterResponse`, etc.
+  Hooks should be provided in the same format that Got expects them and will
+  receive the same arguments Got passes unchanged.
 
 #### Return value
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Creates a new `Shopify` instance.
   GraphQL API, and retry the request after that time has elapsed. Mutually
   exclusive with the `autoLimit` option.
 - `hooks` - Optional - A list of `got`
-  [request hooks](https://github.com/sindresorhus/got/blob/main/documentation/9-hooks.md) to attach
+  [request hooks](https://github.com/sindresorhus/got/tree/v11.8.6#hooks) to attach
   to all outgoing requests, like `beforeRetry`, `afterResponse`, etc. Hooks
   should be provided in the same format that Got expects them and will receive
   the same arguments Got passes unchanged.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Creates a new `Shopify` instance.
   GraphQL API, and retry the request after that time has elapsed. Mutually
   exclusive with the `autoLimit` option.
 - `hooks` - Optional - A list of `got`
-  [request hooks](https://github.com/sindresorhus/got/tree/v11#hooks) to attach
+  [request hooks](https://github.com/sindresorhus/got/blob/main/documentation/9-hooks.md) to attach
   to all outgoing requests, like `beforeRetry`, `afterResponse`, etc. Hooks
   should be provided in the same format that Got expects them and will receive
   the same arguments Got passes unchanged.


### PR DESCRIPTION
Looks like old branches of Got, including `v11` have been removed so the link to the hooks documentation was broken. 