### PR TITLE
Upate README to match Shopify docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ shopify.metafield
   .create({
     key: 'warehouse',
     value: 25,
-    value_type: 'integer',
+    type: 'integer',
     namespace: 'inventory',
     owner_resource: 'product',
     owner_id: 632910392


### PR DESCRIPTION
Using `value_type` as a key in the `params` object was throwing a 422 error:
```
{
  "errors": {
    "value_type": [
      "is not valid"
    ]
  }
} 
```

The Shopify API is expecting `type` as the key.

Fixes #622 