### PR TITLE
Proposing ApiVersion enum

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -780,9 +780,20 @@ declare namespace Shopify {
     interval: number;
   }
 
+  export declare enum ApiVersion {
+    April22 = "2022-04",
+    July22 = "2022-07",
+    October22 = "2022-10",
+    January23 = "2023-01",
+    April23 = "2023-04",
+    July23 = "2023-07",
+    October23 = "2023-10",
+    Unstable = "unstable"
+}
+
   export interface IPublicShopifyConfig {
     accessToken: string;
-    apiVersion?: string;
+    apiVersion?: string | ApiVersion;
     autoLimit?: boolean | IAutoLimit;
     maxRetries?: number;
     presentmentPrices?: boolean;


### PR DESCRIPTION
It seems unusual to have the typescript definitions but leave API Version as string given there's a fixed set of options.

Unsure about your naming conventions, but this PR is just what i'd expect from a package:

1. Export enum of available ApiVersion's
2. Take string | ApiVersion enum, so you can still build if the enum becomes outdated with later releases.

```
import Shopify, { ApiVersion } from 'shopify-api-node';

const client = new Shopify({
    accessToken,
    shopName,
    apiVersion: ApiVersion.July23
})
```

Happy to make any tweaks