### PR TITLE
feat: add agent options

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ Creates a new `Shopify` instance.
   attach to all outgoing requests, like `beforeRetry`, `afterResponse`, etc.
   Hooks should be provided in the same format that Got expects them and will
   receive the same arguments Got passes unchanged.
-- `agent` - Optional - A list of `got`
-  [request agent](https://github.com/sindresorhus/got/tree/v11.8.6?tab=readme-ov-file#agent)
-  This is necessary because a request to one protocol might redirect to another. 
-  In such a scenario, Got will switch over to the right protocol agent for you.
+- `agent` - Optional - An object that is passed as the `agent` option to `got`.
+  This allows to use a proxy server. See
+  [Got documentation](https://github.com/sindresorhus/got/tree/v11.8.6?tab=readme-ov-file#proxies)
+  for more details.
 
 #### Return value
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ Creates a new `Shopify` instance.
   attach to all outgoing requests, like `beforeRetry`, `afterResponse`, etc.
   Hooks should be provided in the same format that Got expects them and will
   receive the same arguments Got passes unchanged.
+- `proxy` - When your computer or server encounters network errors, timeouts, 
+  etc. while accessing Shopify, if you have a proxy server, you can set the 
+  proxy IP(host) and port(port) to resolve issues related to access timeouts and slowness..
 
 #### Return value
 

--- a/README.md
+++ b/README.md
@@ -78,9 +78,10 @@ Creates a new `Shopify` instance.
   attach to all outgoing requests, like `beforeRetry`, `afterResponse`, etc.
   Hooks should be provided in the same format that Got expects them and will
   receive the same arguments Got passes unchanged.
-- `proxy` - When your computer or server encounters network errors, timeouts, 
-  etc. while accessing Shopify, if you have a proxy server, you can set the 
-  proxy IP(host) and port(port) to resolve issues related to access timeouts and slowness..
+- `agent` - Optional - A list of `got`
+  [request agent](https://github.com/sindresorhus/got/tree/v11.8.6?tab=readme-ov-file#agent)
+  This is necessary because a request to one protocol might redirect to another. 
+  In such a scenario, Got will switch over to the right protocol agent for you.
 
 #### Return value
 

--- a/index.js
+++ b/index.js
@@ -287,10 +287,6 @@ Shopify.prototype.graphql = function graphql(data, variables) {
     body: json ? this.options.stringifyJson({ query: data, variables }) : data
   };
 
-  if (this.options.agent) {
-    options.agent = { ...this.options.agent };
-  }
-
   const afterResponse = (res) => {
     if (res.body) {
       if (res.body.extensions && res.body.extensions.cost) {

--- a/index.js
+++ b/index.js
@@ -154,6 +154,7 @@ Shopify.prototype.request = function request(uri, method, key, data, headers) {
     parseJson: this.options.parseJson,
     timeout: this.options.timeout,
     responseType: 'json',
+    agent: this.options.agent,
     method
   };
 

--- a/index.js
+++ b/index.js
@@ -158,10 +158,6 @@ Shopify.prototype.request = function request(uri, method, key, data, headers) {
     method
   };
 
-  if (this.options.agent) {
-    options.agent = { ...this.options.agent };
-  }
-
   const afterResponse = (res) => {
     this.updateLimits(res.headers['x-shopify-shop-api-call-limit']);
     return res;

--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ const url = require('url');
 const pkg = require('./package');
 const resources = require('./resources');
 
-
 const retryableErrorCodes = new Set([
   'ETIMEDOUT',
   'ECONNRESET',

--- a/index.js
+++ b/index.js
@@ -283,6 +283,7 @@ Shopify.prototype.graphql = function graphql(data, variables) {
     timeout: this.options.timeout,
     responseType: 'json',
     method: 'POST',
+    agent: this.options.agent,
     body: json ? this.options.stringifyJson({ query: data, variables }) : data
   };
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ const EventEmitter = require('events');
 const stopcock = require('stopcock');
 const got = require('got');
 const url = require('url');
-const tunnel = require('tunnel');
 
 const pkg = require('./package');
 const resources = require('./resources');
@@ -102,10 +101,6 @@ function Shopify(options) {
       'Basic ' +
       Buffer.from(`${options.apiKey}:${options.password}`).toString('base64');
   }
-  this.proxy = null;
-  if (options.proxy) {
-    this.proxy = {...options.proxy};
-  }
 
   if (options.autoLimit) {
     const conf = transform(
@@ -163,17 +158,8 @@ Shopify.prototype.request = function request(uri, method, key, data, headers) {
     method
   };
 
-  if(this.proxy){
-    const agentHttps = tunnel.httpsOverHttp({
-      proxy: {...this.proxy}
-    });
-    const agentHttp = tunnel.httpOverHttp({
-      proxy: {...this.proxy}
-    });
-    options.agent = {
-      http:agentHttp,
-      https:agentHttps
-    }
+  if (this.options.agent) {
+    options.agent = { ...this.options.agent };
   }
 
   const afterResponse = (res) => {
@@ -303,6 +289,10 @@ Shopify.prototype.graphql = function graphql(data, variables) {
     method: 'POST',
     body: json ? this.options.stringifyJson({ query: data, variables }) : data
   };
+
+  if (this.options.agent) {
+    options.agent = { ...this.options.agent };
+  }
 
   const afterResponse = (res) => {
     if (res.body) {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "got": "^11.1.4",
     "lodash": "^4.17.10",
     "qs": "^6.5.2",
-    "stopcock": "^1.0.0",
-    "tunnel": "^0.0.6"
+    "stopcock": "^1.0.0"
   },
   "devDependencies": {
     "c8": "^7.3.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "got": "^11.1.4",
     "lodash": "^4.17.10",
     "qs": "^6.5.2",
-    "stopcock": "^1.0.0"
+    "stopcock": "^1.0.0",
+    "tunnel": "^0.0.6"
   },
   "devDependencies": {
     "c8": "^7.3.0",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -802,7 +802,7 @@ declare namespace Shopify {
     shopName: string;
     timeout?: number;
     hooks?: Hooks;
-    agent?:Agents;
+    agent?: Agents;
   }
 
   export interface ICallLimits {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,7 @@
 // Type definitions for shopify-api-node
 // Project: shopify-api-node
 // Definitions by: Rich Buggy <rich@buggy.id.au>
-import { Hooks,Agents } from 'got';
+import { Hooks, Agents } from 'got';
 
 /*~ This is the module template file for class modules.
  *~ You should rename it to index.d.ts and place it in a folder with the same name as the module.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -789,7 +789,7 @@ declare namespace Shopify {
     shopName: string;
     timeout?: number;
     hooks?: Hooks;
-    agent?:Agents;
+    agent?: Agents;
   }
 
   export interface IPrivateShopifyConfig {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -789,6 +789,7 @@ declare namespace Shopify {
     shopName: string;
     timeout?: number;
     hooks?: Hooks;
+    proxy?:IProxyConfig;
   }
 
   export interface IPrivateShopifyConfig {
@@ -801,6 +802,12 @@ declare namespace Shopify {
     shopName: string;
     timeout?: number;
     hooks?: Hooks;
+    proxy?:IProxyConfig;
+  }
+
+  export interface IProxyConfig {
+    host:string;
+    port:number;
   }
 
   export interface ICallLimits {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,7 @@
 // Type definitions for shopify-api-node
 // Project: shopify-api-node
 // Definitions by: Rich Buggy <rich@buggy.id.au>
-import { Hooks } from 'got';
+import { Hooks,Agents } from 'got';
 
 /*~ This is the module template file for class modules.
  *~ You should rename it to index.d.ts and place it in a folder with the same name as the module.
@@ -789,7 +789,7 @@ declare namespace Shopify {
     shopName: string;
     timeout?: number;
     hooks?: Hooks;
-    proxy?:IProxyConfig;
+    agent?:Agents;
   }
 
   export interface IPrivateShopifyConfig {
@@ -802,12 +802,7 @@ declare namespace Shopify {
     shopName: string;
     timeout?: number;
     hooks?: Hooks;
-    proxy?:IProxyConfig;
-  }
-
-  export interface IProxyConfig {
-    host:string;
-    port:number;
+    agent?:Agents;
   }
 
   export interface ICallLimits {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -27,7 +27,7 @@ new Shopify({
   }
 });
 
-// Can be constructed with Got proxy.
+// Accepts the `agent` option.
 new Shopify({
   shopName: 'my-shopify-store.myshopify.com',
   accessToken: '111',

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -31,9 +31,15 @@ new Shopify({
 new Shopify({
   shopName: 'my-shopify-store.myshopify.com',
   accessToken: '111',
-  proxy: {
-    host:'127.0.0.1',
-    port:7890
+  agent: {
+    // https: new HttpsProxyAgent({
+    //   keepAlive: true,
+    //   keepAliveMsecs: 1000,
+    //   maxSockets: 256,
+    //   maxFreeSockets: 256,
+    //   scheduling: 'lifo',
+    //   proxy: 'https://localhost:8080'
+    // })
   }
 });
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -27,6 +27,16 @@ new Shopify({
   }
 });
 
+// Can be constructed with Got proxy.
+new Shopify({
+  shopName: 'my-shopify-store.myshopify.com',
+  accessToken: '111',
+  proxy: {
+    host:'127.0.0.1',
+    port:7890
+  }
+});
+
 expectType<number>(client.callLimits.remaining);
 expectType<number>(client.callLimits.current);
 expectType<number>(client.callLimits.max);


### PR DESCRIPTION
When your computer or server encounters network errors, timeouts, etc. while accessing Shopify, if you have a proxy server, you can set the proxy IP and port to resolve issues related to access timeouts and slowness.