### PR TITLE
Add missing customer field in type definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1387,8 +1387,15 @@ declare namespace Shopify {
 
   type CustomerState = 'declined' | 'disabled' | 'enabled' | 'invited';
 
+  interface IEmailMarketingConsent {
+    state: string;
+    opt_in_level: string | null;
+    consent_updated_at: string;
+  }
+
   interface ICustomer {
-    accepts_marketing: boolean;
+    accepts_marketing?: boolean;
+    email_marketing_consent?: IEmailMarketingConsent,
     addresses?: ICustomerAddress[];
     created_at: string;
     currency: string;
@@ -2186,7 +2193,8 @@ declare namespace Shopify {
   }
 
   interface IOrderCustomer {
-    accepts_marketing: boolean;
+    accepts_marketing?: boolean;
+    email_marketing_consent?: IEmailMarketingConsent,
     created_at: string;
     default_address: ICustomerAddress;
     email: string;


### PR DESCRIPTION
`accepts_marketing` is deprecating in latest API version. Adding the field in the interface as a quickfix for downstream projects. 

https://shopify.dev/docs/api/release-notes/2024-01#marketing-fields-and-properties-removals