### PR TITLE
Updating Article type definitions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -996,32 +996,32 @@ declare namespace Shopify {
   }
 
   interface ICreateArticle {
-    author: string;
-    body_html: string;
+    author?: string;
+    body_html?: string;
     handle?: string;
-    image?: IBase64Image;
+    image?: ICreateArticleImage;
     metafields?: ICreateObjectMetafield[];
     published?: boolean;
     published_at?: string;
     summary_html?: string | null;
     tags?: string;
     template_suffix?: string | null;
-    title: string;
+    title?: string;
     user_id?: number;
   }
 
   interface IUpdateArticle {
-    author: string;
-    body_html: string;
+    author?: string;
+    body_html?: string;
     handle?: string;
-    image?: IBase64Image;
+    image?: ICreateArticleImage;
     metafields?: ICreateObjectMetafield[];
     published?: boolean;
     published_at?: string;
     summary_html?: string | null;
     tags?: string;
     template_suffix?: string | null;
-    title: string;
+    title?: string;
     user_id?: number;
   }
 
@@ -1034,8 +1034,10 @@ declare namespace Shopify {
     alt: string | null;
   }
 
-  interface IBase64Image {
-    attachment: string;
+  interface ICreateArticleImage {
+    attachment?: string;
+    src?: string;
+    alt?: string;
   }
 
   interface IObjectMetafield {


### PR DESCRIPTION
This patch is updating Article type definitions to match the documentation on the Shopify Dev Portal. The largest change is the inclusion of a src and alt field on the image, which lets Shopify download an image on your behalf. The remaining fields of both create and update actions have been marked as optional too. The only required field listed in the documentation is the Article ID on updates.

## Added fields to the image type
The [REST API documentation](https://shopify.dev/docs/api/admin-rest/2024-04/resources/article#post-blogs-blog-id-articles) has two examples for adding images, one with the existing base64 data as attachment (called "Create an article with a base64 encoded image") and another with the src and alt fields (called "Create an article with an image, which will be downloaded by Shopify"). The image definition from the second example is copied below.

```
article.image = {
  "src": "http://example.com/rails_logo.gif",
  "alt": "Rails logo"
};
```

I think this change was [mentioned in an old issue](https://github.com/MONEI/Shopify-api-node/issues/288) too.

## Marked all fields as optional
The [REST API documentation](https://shopify.dev/docs/api/admin-rest/2024-04/resources/article#post-blogs-blog-id-articles) lists only two fields as required: api_version and blog_id. Since the Blog ID is part of the URL (and obviously required for that) and the API Version comes through a header (and not even present in the examples given), I'm not sure why they bothered to list them.

## Why not use the GraphQL API?
Unfortunately, the Article mutations are in the unstable graphql branch so they're at least a few months out from hitting a full release. Interestingly though, the [GraphQL API documentation](https://shopify.dev/docs/api/admin-graphql/unstable/mutations/onlineStoreArticleCreate) also marks none of the fields as required, so the intention here will probably continue.
