### PR TITLE
Fixed type of ICustomer.multipass_identifier

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1406,7 +1406,7 @@ declare namespace Shopify {
     last_name: string;
     metafield?: IObjectMetafield; // From https://help.shopify.com/api/reference/customer but not visible in test API call
     phone: string;
-    multipass_identifier: null;
+    multipass_identifier: string | null;
     last_order_id: number | null;
     last_order_name: string | null;
     note: string | null;


### PR DESCRIPTION
I suspect that "multipass_identifier: null" was never the intent...