### PR TITLE
Add current_quantity to IOrderLineItem inteface

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2311,6 +2311,7 @@ declare namespace Shopify {
   }
 
   interface IOrderLineItem {
+    current_quantity?: number;
     discount_allocations: ILineItemDiscountAllocation[];
     fulfillable_quantity: number;
     fulfillment_service: string;


### PR DESCRIPTION
The current_quantity field is added in api version 2024-01
https://shopify.dev/changelog/addition-of-lineitem-current_quantity-on-admin-rest-api

The field is optional because some older api version (e.g. 2023-10) does not have it.