### PR TITLE
resolves issue #669

### DIFF
--- a/index.js
+++ b/index.js
@@ -273,13 +273,12 @@ Shopify.prototype.graphql = function graphql(data, variables) {
   pathname += '/graphql.json';
 
   const uri = { pathname, ...this.baseUrl };
-  const json = variables !== undefined && variables !== null;
   const options = {
     agent: this.options.agent,
-    body: json ? this.options.stringifyJson({ query: data, variables }) : data,
+    body: this.options.stringifyJson({ query: data, variables }),
     headers: {
       ...this.baseHeaders,
-      'Content-Type': json ? 'application/json' : 'application/graphql'
+      'Content-Type': 'application/json'
     },
     method: 'POST',
     parseJson: this.options.parseJson,


### PR DESCRIPTION
This issue resolves https://github.com/MONEI/Shopify-api-node/issues/669

Based on https://shopify.dev/changelog/graphql-over-http:

```
For requests to 2025-01 versions and after:

Use the /graphql endpoint. Using /graphql.json will automatically respond with application/json as it does now.
The request body must contain a [spec JSON encoding](https://graphql.github.io/graphql-over-http/draft/#sec-JSON-Encoding).
The Content-Type header must specify application/json. The legacy application/graphql request format is no longer supported. Requests with no supported content type will receive a 415 Unsupported Media Type response.
The Accept header now supports application/graphql-response+json and/or application/json response formats. Requests with no supported accept types will receive a 406 Not Acceptable response.
```

This change is backwards compatible as old api versions accept json requests like this