### PR TITLE
allows users to provide a hook when graphql protected customer data e…

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -786,6 +786,16 @@ declare namespace Shopify {
     interval: number;
   }
 
+  export interface IProtectedCustomerDataError {
+    message: string;
+    path: string[];
+    extension: {
+      code: 'ACCESS_DENIED';
+      documentation: string;
+      requiredAccess: string;
+    };
+  }
+
   export interface IPublicShopifyConfig {
     accessToken: string;
     apiVersion?: string;
@@ -796,6 +806,9 @@ declare namespace Shopify {
     timeout?: number;
     hooks?: Hooks;
     agent?: Agents;
+    onProtectedCustomerDataError?: (
+      errors: IProtectedCustomerDataError[]
+    ) => void;
   }
 
   export interface IPrivateShopifyConfig {


### PR DESCRIPTION
Gadget has just completed migrating all of our Shopify syncing engine to using the GraphQL api exclusively. One pain point in doing so was dealing with models that have protected customer data fields. Because there is no way to know if an app has filled out the form to request specific customer data fields the only way to know if Gadget can query these fields on apps behalf is to try.

Unfortunately with the way that shopify-api-node is currently set up, if an app does not have access the query will throw since shopify populates the `errors` field. However they also will return the data for the query, but with `null` in the place of the protected fields.

I think the default behaviour of throwing if the `errors` field is populated makes sense, however in this case we would like the option to not throw.

To resolve this I have added a configuration to the client `onProtectedCustomerDataError` that allows for custom handling of this situation.

Let me know what you think

cc @lpinca  @airhorns @jcao49